### PR TITLE
feat(dict): StarDict .syn synonym index + HTML-formatted definitions

### DIFF
--- a/__tests__/htmlToPlainText.test.ts
+++ b/__tests__/htmlToPlainText.test.ts
@@ -1,0 +1,141 @@
+import {htmlToPlainText, looksLikeHtml} from '../src/ui/htmlToPlainText';
+
+describe('looksLikeHtml', () => {
+  test('detects opening tags', () => {
+    expect(looksLikeHtml('<i>hi</i>')).toBe(true);
+  });
+
+  test('detects self-closing tags', () => {
+    expect(looksLikeHtml('hi<br/>there')).toBe(true);
+  });
+
+  test('rejects plain text', () => {
+    expect(looksLikeHtml('a greeting used for most purposes')).toBe(false);
+  });
+
+  test('rejects text with stray angle brackets', () => {
+    expect(looksLikeHtml('x < y')).toBe(false);
+  });
+});
+
+describe('htmlToPlainText', () => {
+  test('returns plain text unchanged (idempotent on no-tag input)', () => {
+    const text = 'a greeting used for most purposes';
+    expect(htmlToPlainText(text)).toBe(text);
+  });
+
+  test('strips inline tags but keeps text content', () => {
+    expect(htmlToPlainText('<i>intj</i>')).toBe('intj');
+    expect(htmlToPlainText('<b>bold</b> and <span>span</span>')).toBe(
+      'bold and span',
+    );
+  });
+
+  test('converts <br> to newline', () => {
+    expect(htmlToPlainText('a<br>b<br/>c<br />d')).toBe('a\nb\nc\nd');
+  });
+
+  test('converts <li> to bulleted line', () => {
+    expect(htmlToPlainText('<ol><li>first</li><li>second</li></ol>')).toBe(
+      '• first\n• second',
+    );
+  });
+
+  test('renders the real-world Wiktionary namaste entry readably', () => {
+    const html =
+      '<i>intj</i><br><ol><li>A salutation; a greeting used for most ' +
+      'purposes including hello</li></ol><br><ol><i>noun</i><br><ol>' +
+      '<li>greeting, salutation, an instance of the interjection ' +
+      'namaste</li></ol>';
+    const out = htmlToPlainText(html);
+    expect(out).toContain('intj');
+    expect(out).toContain('• A salutation; a greeting used for most purposes');
+    expect(out).toContain('noun');
+    expect(out).toContain(
+      '• greeting, salutation, an instance of the interjection namaste',
+    );
+    // No tags leak through.
+    expect(out).not.toMatch(/<\/?[a-z]/i);
+  });
+
+  test('decodes named HTML entities', () => {
+    expect(htmlToPlainText('AT&amp;T')).toBe('AT&T');
+    expect(htmlToPlainText('1 &lt; 2 &gt; 0')).toBe('1 < 2 > 0');
+    expect(htmlToPlainText('&quot;hi&quot;')).toBe('"hi"');
+    expect(htmlToPlainText('it&apos;s')).toBe("it's");
+    expect(htmlToPlainText('a&nbsp;b')).toBe('a b');
+  });
+
+  test('decodes numeric HTML entities (decimal and hex)', () => {
+    expect(htmlToPlainText('&#65;&#66;')).toBe('AB');
+    expect(htmlToPlainText('&#x41;&#x42;')).toBe('AB');
+    expect(htmlToPlainText('&#X41;')).toBe('A');
+  });
+
+  test('drops unknown / malformed entities cleanly', () => {
+    // Unknown name -> empty string.
+    expect(htmlToPlainText('a &totallymadeup; b')).toBe('a b');
+    // No semicolon within 10 chars -> treat & as literal.
+    expect(htmlToPlainText('use & for and')).toBe('use & for and');
+  });
+
+  test('treats malformed unclosed tag as literal text rather than dropping', () => {
+    expect(htmlToPlainText('a <unclosed b c')).toBe('a <unclosed b c');
+  });
+
+  test('preserves trailing unclosed-tag content after a well-formed tag', () => {
+    // After a real <i>...</i> the looksLikeHtml short-circuit doesn't
+    // fire, so the loop walks into the trailing '<unclosed'. The
+    // malformed-tag path inside the loop should keep that suffix as
+    // literal text rather than dropping it silently.
+    expect(htmlToPlainText('<i>good</i> tail <unclosed extra')).toBe(
+      'good tail <unclosed extra',
+    );
+  });
+
+  test('treats an empty entity (&;) as no character', () => {
+    expect(htmlToPlainText('a&;b')).toBe('ab');
+  });
+
+  test('collapses runs of whitespace and newlines', () => {
+    const messy = '<p>x</p>     <p>y</p><br><br><br>z';
+    const out = htmlToPlainText(messy);
+    expect(out).not.toMatch(/ {3}/); // no triple-space
+    expect(out).not.toMatch(/\n{3,}/); // no triple-newline
+    expect(out).toContain('x');
+    expect(out).toContain('y');
+    expect(out).toContain('z');
+  });
+
+  test('handles attributes on tags (drops them along with the tag)', () => {
+    expect(htmlToPlainText('<a href="https://x">link</a>')).toBe('link');
+    expect(htmlToPlainText('<li class="bullet">x</li>')).toBe('• x');
+  });
+
+  test('handles uppercase / mixed-case tag names', () => {
+    expect(htmlToPlainText('<I>x</I><BR/><LI>y</LI>')).toBe('x\n• y');
+  });
+
+  test('rejects out-of-range numeric entities silently', () => {
+    expect(htmlToPlainText('&#999999999;')).toBe('');
+    expect(htmlToPlainText('&#0;')).toBe('');
+  });
+
+  test('handles empty string', () => {
+    expect(htmlToPlainText('')).toBe('');
+  });
+
+  test('handles content with only tags (returns empty after strip)', () => {
+    expect(htmlToPlainText('<br><br>')).toBe('');
+  });
+
+  test('preserves UTF-8 / multi-byte content inside tags', () => {
+    expect(htmlToPlainText('<i>नमस्ते</i>')).toBe('नमस्ते');
+  });
+
+  test('does not run the converter for plain ASCII text without entities', () => {
+    // Performance contract: no `<` and no `&` => exact same string out.
+    const plain = 'A simple definition that uses no HTML at all.';
+    expect(htmlToPlainText(plain)).toBe(plain);
+  });
+});

--- a/__tests__/parseSyn.test.ts
+++ b/__tests__/parseSyn.test.ts
@@ -1,0 +1,70 @@
+import {parseSyn} from '../src/core/dict/stardict/parseSyn';
+
+const enc = (s: string) => new TextEncoder().encode(s);
+
+const buildSyn = (entries: {word: string; index: number}[]): Uint8Array => {
+  /* eslint-disable no-bitwise */
+  const parts: number[] = [];
+  for (const {word, index} of entries) {
+    for (const b of enc(word)) {
+      parts.push(b);
+    }
+    parts.push(0);
+    parts.push((index >>> 24) & 0xff);
+    parts.push((index >>> 16) & 0xff);
+    parts.push((index >>> 8) & 0xff);
+    parts.push(index & 0xff);
+  }
+  return new Uint8Array(parts);
+  /* eslint-enable no-bitwise */
+};
+
+describe('parseSyn', () => {
+  test('parses a simple sequence of synonym -> idx-index records', () => {
+    const bytes = buildSyn([
+      {word: 'namaste', index: 5},
+      {word: 'dhanyavad', index: 12},
+      {word: 'paani', index: 200},
+    ]);
+    expect(parseSyn(bytes)).toEqual([
+      {word: 'namaste', originalWordIndex: 5},
+      {word: 'dhanyavad', originalWordIndex: 12},
+      {word: 'paani', originalWordIndex: 200},
+    ]);
+  });
+
+  test('decodes UTF-8 multi-byte words', () => {
+    const bytes = buildSyn([
+      {word: 'нет', index: 1}, // Cyrillic
+      {word: 'नमस्ते', index: 2}, // Devanagari
+    ]);
+    expect(parseSyn(bytes)).toEqual([
+      {word: 'нет', originalWordIndex: 1},
+      {word: 'नमस्ते', originalWordIndex: 2},
+    ]);
+  });
+
+  test('handles a large 32-bit big-endian index', () => {
+    const bytes = buildSyn([{word: 'big', index: 0x01020304}]);
+    expect(parseSyn(bytes)[0].originalWordIndex).toBe(0x01020304);
+  });
+
+  test('returns [] for empty input', () => {
+    expect(parseSyn(new Uint8Array(0))).toEqual([]);
+  });
+
+  test('throws on a record with an empty word', () => {
+    const bytes = new Uint8Array([0, 0, 0, 0, 0]); // \0 + 4 zero index bytes
+    expect(() => parseSyn(bytes)).toThrow(/empty word/);
+  });
+
+  test('throws on an unterminated word at end of buffer', () => {
+    const bytes = new Uint8Array([0x66, 0x6f, 0x6f]); // "foo" with no \0
+    expect(() => parseSyn(bytes)).toThrow(/unterminated word/);
+  });
+
+  test('throws on a truncated index (less than 4 bytes after \\0)', () => {
+    const bytes = new Uint8Array([0x66, 0x6f, 0x6f, 0, 0, 0]); // "foo\0" + only 2 bytes
+    expect(() => parseSyn(bytes)).toThrow(/truncated record/);
+  });
+});

--- a/__tests__/stardictDict.test.ts
+++ b/__tests__/stardictDict.test.ts
@@ -78,4 +78,122 @@ describe('stardictDict', () => {
     const parsed = buildDict(ifo, idx, dict);
     expect(lookupDict(parsed, 'apple')?.canonicalWord).toBe('Apple');
   });
+
+  describe('synonym (.syn) merge', () => {
+    // Synonym index format: word \0 + index_u32_be (0-based into the
+    // sorted .idx entries array). Hand-build small .syn buffers to
+    // verify the merge logic without relying on a real dict.
+    const enc = (s: string) => new TextEncoder().encode(s);
+    const buildSyn = (
+      pairs: {word: string; index: number}[],
+    ): Uint8Array => {
+      /* eslint-disable no-bitwise */
+      const parts: number[] = [];
+      for (const {word, index} of pairs) {
+        for (const b of enc(word)) {
+          parts.push(b);
+        }
+        parts.push(0);
+        parts.push((index >>> 24) & 0xff);
+        parts.push((index >>> 16) & 0xff);
+        parts.push((index >>> 8) & 0xff);
+        parts.push(index & 0xff);
+      }
+      return new Uint8Array(parts);
+      /* eslint-enable no-bitwise */
+    };
+
+    test('synonym lookup resolves to the canonical .idx entry', () => {
+      // Real-world case: Devanagari-only .idx + Latin transliterations
+      // in .syn. The synthetic builder uses Latin keys but the
+      // mechanics are identical — synonym maps to entry by index.
+      // Entries sort byte-wise: apple (0), banana (1), cherry (2).
+      const {ifo, idx, dict} = buildSyntheticStarDict({
+        apple: 'a fruit',
+        banana: 'a yellow fruit',
+        cherry: 'a small red fruit',
+      });
+      const syn = buildSyn([
+        {word: 'malum', index: 0}, // alias for apple
+        {word: 'pomum', index: 0}, // another alias for apple
+        {word: 'cerasus', index: 2}, // alias for cherry
+      ]);
+      const parsed = buildDict(ifo, idx, dict, syn);
+      // Synonym lookups resolve to the canonical entry.
+      expect(lookupDict(parsed, 'malum')).toEqual({
+        canonicalWord: 'apple',
+        definition: 'a fruit',
+      });
+      expect(lookupDict(parsed, 'pomum')).toEqual({
+        canonicalWord: 'apple',
+        definition: 'a fruit',
+      });
+      expect(lookupDict(parsed, 'cerasus')).toEqual({
+        canonicalWord: 'cherry',
+        definition: 'a small red fruit',
+      });
+      // The original .idx entries still work.
+      expect(lookupDict(parsed, 'apple')?.definition).toBe('a fruit');
+    });
+
+    test('synonym lookup is case-insensitive', () => {
+      const {ifo, idx, dict} = buildSyntheticStarDict({apple: 'a fruit'});
+      const syn = buildSyn([{word: 'MALUM', index: 0}]);
+      const parsed = buildDict(ifo, idx, dict, syn);
+      expect(lookupDict(parsed, 'malum')?.definition).toBe('a fruit');
+      expect(lookupDict(parsed, 'Malum')?.definition).toBe('a fruit');
+    });
+
+    test('synonyms do not shadow existing .idx entries (idx wins)', () => {
+      // If a synonym happens to match an existing headword, the .idx
+      // entry already in the map keeps its place. Otherwise a bad
+      // .syn could silently swap definitions.
+      const {ifo, idx, dict} = buildSyntheticStarDict({
+        apple: 'real apple',
+        cherry: 'real cherry',
+      });
+      // Synonym "apple" attempting to point at cherry's index. Should
+      // be ignored — apple already maps to its own entry.
+      const syn = buildSyn([{word: 'apple', index: 1}]);
+      const parsed = buildDict(ifo, idx, dict, syn);
+      expect(lookupDict(parsed, 'apple')?.definition).toBe('real apple');
+    });
+
+    test('out-of-range synonym index is skipped silently', () => {
+      const {ifo, idx, dict} = buildSyntheticStarDict({apple: 'a fruit'});
+      // index 99 doesn't exist (we have only entry 0).
+      const syn = buildSyn([{word: 'badref', index: 99}]);
+      const parsed = buildDict(ifo, idx, dict, syn);
+      expect(lookupDict(parsed, 'badref')).toBeNull();
+      // The good entries still work.
+      expect(lookupDict(parsed, 'apple')?.definition).toBe('a fruit');
+    });
+
+    test('empty .syn buffer is treated as no synonyms', () => {
+      const {ifo, idx, dict} = buildSyntheticStarDict({apple: 'a fruit'});
+      const parsed = buildDict(ifo, idx, dict, new Uint8Array(0));
+      expect(lookupDict(parsed, 'apple')?.definition).toBe('a fruit');
+    });
+
+    test('omitted .syn parameter is equivalent to no synonym index', () => {
+      const {ifo, idx, dict} = buildSyntheticStarDict({apple: 'a fruit'});
+      const parsed = buildDict(ifo, idx, dict);
+      expect(lookupDict(parsed, 'apple')?.definition).toBe('a fruit');
+    });
+
+    test('multi-byte synonym word (Devanagari) resolves correctly', () => {
+      // Real Wiktionary case: native script in .idx, Latin in .syn.
+      // Here the synthetic dict has Latin in .idx and Devanagari in
+      // .syn — same mechanics, just inverted scripts.
+      const {ifo, idx, dict} = buildSyntheticStarDict({
+        namaste: 'a Hindi greeting',
+      });
+      const syn = buildSyn([{word: 'नमस्ते', index: 0}]);
+      const parsed = buildDict(ifo, idx, dict, syn);
+      expect(lookupDict(parsed, 'नमस्ते')).toEqual({
+        canonicalWord: 'namaste',
+        definition: 'a Hindi greeting',
+      });
+    });
+  });
 });

--- a/__tests__/userDictDiscovery.test.ts
+++ b/__tests__/userDictDiscovery.test.ts
@@ -503,4 +503,101 @@ describe('discoverUserDicts', () => {
       (deps.logger?.warn as jest.Mock).mock.calls.flat().join(' '),
     ).toMatch(/no recognised dict files/);
   });
+
+  test('discovers a StarDict folder with a .syn file alongside the triple', async () => {
+    // Build a synthetic dict with Latin headwords + a synonym index
+    // aliasing one of them, so we can verify the .syn fetch + merge
+    // path end-to-end through discovery.
+    const triple = stardictBytes({apple: 'a fruit (canonical)'});
+    // Hand-build a tiny .syn pointing the alias "malum" at idx[0].
+    const synBytes = new Uint8Array([
+      // 'malum'
+      0x6d, 0x61, 0x6c, 0x75, 0x6d,
+      0,
+      // index 0, big-endian u32
+      0, 0, 0, 0,
+    ]);
+    const synBuffer = synBytes.buffer.slice(
+      synBytes.byteOffset,
+      synBytes.byteOffset + synBytes.byteLength,
+    ) as ArrayBuffer;
+    const deps = baseDeps({
+      [`${ROOT}/wiki/dict.ifo`]: triple.ifo,
+      [`${ROOT}/wiki/dict.idx`]: triple.idx,
+      [`${ROOT}/wiki/dict.dict.dz`]: triple.dict,
+      [`${ROOT}/wiki/dict.syn`]: synBuffer,
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(sources.length).toBe(1);
+    // The synonym "malum" resolves to apple's canonical entry.
+    expect((await sources[0].lookup('malum'))?.definition).toBe(
+      'a fruit (canonical)',
+    );
+    expect((await sources[0].lookup('apple'))?.definition).toBe(
+      'a fruit (canonical)',
+    );
+  });
+
+  test('StarDict folder with no .syn still discovers and works', async () => {
+    // Back-compat: dicts without a .syn file should behave exactly as
+    // they did before .syn support landed.
+    const triple = stardictBytes({apple: 'a fruit'});
+    const deps = baseDeps({
+      [`${ROOT}/plain/dict.ifo`]: triple.ifo,
+      [`${ROOT}/plain/dict.idx`]: triple.idx,
+      [`${ROOT}/plain/dict.dict.dz`]: triple.dict,
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(sources.length).toBe(1);
+    expect((await sources[0].lookup('apple'))?.definition).toBe('a fruit');
+  });
+
+  test('a failing .syn fetch is non-fatal (dict still loads without synonyms)', async () => {
+    const triple = stardictBytes({apple: 'a fruit'});
+    const fileUtils: FileUtilsLike = {
+      exists: jest.fn(async () => true),
+      listFiles: jest.fn(async (path: string) => {
+        if (path === ROOT) {
+          return [fileEntry(`${ROOT}/wiki`, 0)];
+        }
+        return [
+          fileEntry(`${ROOT}/wiki/dict.ifo`, 1),
+          fileEntry(`${ROOT}/wiki/dict.idx`, 1),
+          fileEntry(`${ROOT}/wiki/dict.dict.dz`, 1),
+          fileEntry(`${ROOT}/wiki/dict.syn`, 1),
+        ];
+      }),
+    };
+    const fetchFn = jest.fn(async (url: string) => {
+      const path = url.replace(/^file:\/\//, '');
+      if (path.endsWith('.syn')) {
+        // Simulate a fetch failure on .syn only.
+        throw new Error('syn read failed');
+      }
+      if (path.endsWith('.ifo')) {
+        return {ok: true, status: 200, arrayBuffer: async () => triple.ifo} as Response;
+      }
+      if (path.endsWith('.idx')) {
+        return {ok: true, status: 200, arrayBuffer: async () => triple.idx} as Response;
+      }
+      if (path.endsWith('.dict.dz')) {
+        return {ok: true, status: 200, arrayBuffer: async () => triple.dict} as Response;
+      }
+      return {ok: false, status: 404, arrayBuffer: async () => new ArrayBuffer(0)} as Response;
+    });
+    const logger = buildLogger();
+    const sources = await discoverUserDicts({
+      fileUtils,
+      fetchFn: fetchFn as unknown as typeof fetch,
+      logger,
+      rootPath: ROOT,
+    });
+    expect(sources.length).toBe(1);
+    // Dict still works with .idx-only headwords.
+    expect((await sources[0].lookup('apple'))?.definition).toBe('a fruit');
+    // The .syn failure was logged with our continuation message.
+    expect(
+      (logger.warn as jest.Mock).mock.calls.flat().join(' '),
+    ).toMatch(/\.syn fetch threw.*continuing without synonyms/);
+  });
 });

--- a/src/core/dict/stardict/parseSyn.ts
+++ b/src/core/dict/stardict/parseSyn.ts
@@ -1,0 +1,54 @@
+// StarDict `.syn` (synonym index) parser.
+// Format: a packed sequence of records:
+//   word (UTF-8) \0 original_word_index (4 bytes big-endian unsigned)
+//
+// `original_word_index` is the 0-based ordinal of an entry in the
+// sorted `.idx` list. A `.syn` entry maps an alternate spelling /
+// transliteration / inflected form to the canonical .idx entry, so
+// looking up the synonym should resolve to the same .dict definition.
+//
+// `.syn` is optional in StarDict; many dicts omit it. Its presence is
+// load-bearing for cross-script lookups (e.g. Wiktionary Hindi-English
+// keeps Devanagari headwords in `.idx` and Latin transliterations in
+// `.syn` — without reading `.syn`, "namaste" would never match the
+// नमस्ते entry).
+
+import {decodeUtf8} from '../../../sdk/utf8';
+
+export type SynEntry = {
+  word: string;
+  // Index into the parsed .idx entries array (0-based).
+  originalWordIndex: number;
+};
+
+export const parseSyn = (bytes: Uint8Array): SynEntry[] => {
+  const entries: SynEntry[] = [];
+  const view = new DataView(
+    bytes.buffer,
+    bytes.byteOffset,
+    bytes.byteLength,
+  );
+  let i = 0;
+  while (i < bytes.length) {
+    let end = i;
+    while (end < bytes.length && bytes[end] !== 0) {
+      end++;
+    }
+    if (end >= bytes.length) {
+      throw new Error('parseSyn: unterminated word at end of buffer');
+    }
+    if (end === i) {
+      throw new Error(`parseSyn: empty word at offset ${i}`);
+    }
+    if (end + 1 + 4 > bytes.length) {
+      throw new Error(
+        `parseSyn: truncated record after word at offset ${i}`,
+      );
+    }
+    const word = decodeUtf8(bytes.subarray(i, end));
+    const originalWordIndex = view.getUint32(end + 1, false);
+    entries.push({word, originalWordIndex});
+    i = end + 1 + 4;
+  }
+  return entries;
+};

--- a/src/core/dict/stardict/stardictDict.ts
+++ b/src/core/dict/stardict/stardictDict.ts
@@ -1,4 +1,4 @@
-// Orchestrator: takes the three StarDict file buffers, parses them, and
+// Orchestrator: takes the StarDict file buffers, parses them, and
 // exposes a case-insensitive lookup that returns the raw definition
 // text for a word (or null when not found). Stays format-pure: no
 // React, no SDK, no I/O — easy to unit-test.
@@ -7,6 +7,7 @@ import type {IfoMeta} from './parseIfo';
 import {parseIfo} from './parseIfo';
 import type {IdxEntry} from './parseIdx';
 import {parseIdx} from './parseIdx';
+import {parseSyn} from './parseSyn';
 import {decompressDict} from './decompressDict';
 import {decodeUtf8} from '../../../sdk/utf8';
 
@@ -14,8 +15,9 @@ export type ParsedDict = {
   meta: IfoMeta;
   // Lowercase word -> the first matching .idx entry. We index
   // case-insensitively so "Hello", "HELLO", and "hello" all hit the
-  // same record. If the source has duplicate-key collisions across
-  // case variants, the first one in .idx order wins (deterministic).
+  // same record. Synonyms from .syn (if present) are merged into the
+  // same map pointing at their canonical .idx entry. If the source
+  // has duplicate-key collisions, the first one wins (deterministic).
   index: Map<string, IdxEntry>;
   dictBytes: Uint8Array;
 };
@@ -29,6 +31,12 @@ export const buildDict = (
   ifoBytes: Uint8Array,
   idxBytes: Uint8Array,
   dictBytes: Uint8Array,
+  // Optional .syn synonym index. Each .syn entry is (synonym word ->
+  // index into the .idx entries array); we resolve those to the
+  // canonical IdxEntry and merge into the lookup map. Critical for
+  // cross-script lookups (e.g. Wiktionary Hindi-English's Latin
+  // transliterations live in .syn, not .idx).
+  synBytes?: Uint8Array,
 ): ParsedDict => {
   const meta = parseIfo(ifoBytes);
   const entries = parseIdx(idxBytes, meta.idxoffsetbits);
@@ -38,6 +46,25 @@ export const buildDict = (
     const key = e.word.toLowerCase();
     if (!index.has(key)) {
       index.set(key, e);
+    }
+  }
+  if (synBytes && synBytes.length > 0) {
+    const synEntries = parseSyn(synBytes);
+    for (const syn of synEntries) {
+      const target = entries[syn.originalWordIndex];
+      if (target === undefined) {
+        // Out-of-range index — skip silently rather than failing the
+        // whole dict. A handful of bad synonym pointers shouldn't
+        // dead-end an otherwise-fine dictionary.
+        continue;
+      }
+      const key = syn.word.toLowerCase();
+      if (!index.has(key)) {
+        // Synonym keys point at the SAME canonical .idx entry, so the
+        // popup's headerWord (entry.word) shows the original headword,
+        // not the synonym alias the user typed.
+        index.set(key, target);
+      }
     }
   }
   return {meta, index, dictBytes: decompressed};

--- a/src/core/dict/stardictLookup.ts
+++ b/src/core/dict/stardictLookup.ts
@@ -13,6 +13,10 @@ export type DictBytes = {
   ifo: Uint8Array;
   idx: Uint8Array;
   dict: Uint8Array;
+  // Optional StarDict synonym index. If present, alternate spellings
+  // / transliterations / inflected forms get merged into the lookup
+  // map alongside the .idx headwords.
+  syn?: Uint8Array;
 };
 
 export type LoadDictBytes = () => Promise<DictBytes | null>;
@@ -46,7 +50,7 @@ export const createStardictLookup = (
       return;
     }
     try {
-      dict = buildDict(bytes.ifo, bytes.idx, bytes.dict);
+      dict = buildDict(bytes.ifo, bytes.idx, bytes.dict, bytes.syn);
     } catch (e) {
       warn(`[${tag}] buildDict threw: ${(e as Error).message}`);
       throw e;

--- a/src/core/dict/userDictDiscovery.ts
+++ b/src/core/dict/userDictDiscovery.ts
@@ -112,7 +112,17 @@ const readMetaName = async (
 };
 
 type DetectedFormat =
-  | {kind: 'stardict'; ifo: string; idx: string; dict: string}
+  | {
+      kind: 'stardict';
+      ifo: string;
+      idx: string;
+      dict: string;
+      // Optional StarDict synonym index file. Wiktionary-derived
+      // dicts use this to ship Latin transliterations alongside
+      // native-script headwords; reading it makes Latin lookups
+      // work for non-Latin-script languages.
+      syn?: string;
+    }
   | {kind: 'csv'; path: string}
   | {kind: 'json'; path: string}
   | {kind: 'mdx'; path: string}
@@ -126,6 +136,7 @@ const detectFormat = (files: FileEntry[]): DetectedFormat => {
   const dict = filesOnly.find(
     f => extOf(f.path) === '.dict.dz' || extOf(f.path) === '.dict',
   );
+  const syn = filesOnly.find(f => extOf(f.path) === '.syn');
   const csv = filesOnly.find(f => extOf(f.path) === '.csv');
   // Exclude meta.json from JSON dict candidates.
   const json = filesOnly.find(
@@ -168,7 +179,13 @@ const detectFormat = (files: FileEntry[]): DetectedFormat => {
   }
   // present.length === 1 by elimination: pick the matching detector.
   if (stardictComplete) {
-    return {kind: 'stardict', ifo: ifo.path, idx: idx.path, dict: dict.path};
+    return {
+      kind: 'stardict',
+      ifo: ifo.path,
+      idx: idx.path,
+      dict: dict.path,
+      syn: syn ? syn.path : undefined,
+    };
   }
   if (csv) {
     return {kind: 'csv', path: csv.path};
@@ -212,15 +229,27 @@ const buildSourceForFolder = async (
   const displayName = metaName ?? folderName;
 
   if (detected.kind === 'stardict') {
+    const synPath = detected.syn;
     return createStardictLookup({
       name: displayName,
       loadBase: async (): Promise<DictBytes | null> => {
-        const [ifo, idx, dict] = await Promise.all([
+        const [ifo, idx, dict, syn] = await Promise.all([
           fetchAsUint8(detected.ifo, fetchFn),
           fetchAsUint8(detected.idx, fetchFn),
           fetchAsUint8(detected.dict, fetchFn),
+          // .syn is optional. Fetch failures here aren't fatal — fall
+          // back to the .idx-only path, which is what we did before
+          // .syn support landed.
+          synPath
+            ? fetchAsUint8(synPath, fetchFn).catch(e => {
+                logger.warn(
+                  `${TAG} folder "${folderName}" .syn fetch threw: ${(e as Error).message} — continuing without synonyms`,
+                );
+                return undefined;
+              })
+            : Promise.resolve(undefined),
         ]);
-        return {ifo, idx, dict};
+        return syn ? {ifo, idx, dict, syn} : {ifo, idx, dict};
       },
       logger,
     });

--- a/src/ui/DefinitionPopup.tsx
+++ b/src/ui/DefinitionPopup.tsx
@@ -12,6 +12,7 @@ import {
   parseWordNetEntry,
   type WordNetSense,
 } from './wordnetFormatter';
+import {htmlToPlainText} from './htmlToPlainText';
 import {t} from '../i18n/i18n';
 import type {SourceHit} from '../core/lookup';
 
@@ -121,7 +122,14 @@ const SourceSection = ({
     {parsed && !parsed.parseFailed ? (
       <SenseList senses={parsed.senses} />
     ) : (
-      <Text style={styles.definition}>{hit.entry.definition}</Text>
+      // Fallback for non-WordNet content. Run through the HTML
+      // stripper so dicts with sametypesequence=h (Wiktionary-derived
+      // StarDicts and similar) render as readable plain text instead
+      // of leaking <i>/<br>/<ol>/<li> tags into the popup. No-op for
+      // genuinely plain text (no `<` or `&`).
+      <Text style={styles.definition}>
+        {htmlToPlainText(hit.entry.definition)}
+      </Text>
     )}
   </View>
 );

--- a/src/ui/htmlToPlainText.ts
+++ b/src/ui/htmlToPlainText.ts
@@ -1,0 +1,121 @@
+// Convert HTML-formatted definition text into plain text suitable for
+// the popup's fallback render path. Used for StarDict dicts whose
+// .ifo declares `sametypesequence=h` (Wiktionary-derived dicts in
+// particular), and as a safety net for any user-authored CSV/JSON
+// definition that happens to contain HTML.
+//
+// Design constraints:
+// - Single-pass, no DOM, no regex over the whole string. RN's JS engine
+//   has no DOMParser; pulling in an HTML parser library is overkill for
+//   the structural-tag set dicts use in practice.
+// - Idempotent on plain text (no `<` or `&` -> output equals input
+//   modulo whitespace collapse). WordNet entries flow through
+//   untouched; the existing parseWordNetEntry path still runs first.
+// - Conservative tag handling: known structural tags get layout
+//   substitutions; everything else is dropped (content kept).
+
+const ENTITY_MAP: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+const decodeEntity = (entity: string): string => {
+  if (entity.length === 0) {
+    return '';
+  }
+  if (entity[0] === '#') {
+    const isHex = entity[1] === 'x' || entity[1] === 'X';
+    const codepoint = isHex
+      ? parseInt(entity.slice(2), 16)
+      : parseInt(entity.slice(1), 10);
+    if (Number.isFinite(codepoint) && codepoint > 0 && codepoint <= 0x10ffff) {
+      try {
+        return String.fromCodePoint(codepoint);
+      } catch {
+        return '';
+      }
+    }
+    return '';
+  }
+  return ENTITY_MAP[entity.toLowerCase()] ?? '';
+};
+
+// Identify the bare tag name from "<i>", "</i>", "<br/>", "<li class=x>".
+// Returns lowercased name without the leading slash.
+const tagNameOf = (rawTag: string): string => {
+  const trimmed = rawTag.trim();
+  const stripped = trimmed.startsWith('/') ? trimmed.slice(1) : trimmed;
+  const spaceOrSlash = stripped.search(/[\s/>]/);
+  return (spaceOrSlash < 0 ? stripped : stripped.slice(0, spaceOrSlash)).toLowerCase();
+};
+
+const HAS_HTML_TAG = /<\/?[a-zA-Z][^>]*>/;
+
+// Returns true if the input looks like HTML (contains at least one
+// well-formed-looking tag). Lets the popup short-circuit and skip the
+// converter for plain text.
+export const looksLikeHtml = (s: string): boolean => HAS_HTML_TAG.test(s);
+
+export const htmlToPlainText = (html: string): string => {
+  if (!looksLikeHtml(html) && html.indexOf('&') < 0) {
+    return html;
+  }
+  let out = '';
+  let i = 0;
+  while (i < html.length) {
+    const ch = html[i];
+    if (ch === '<') {
+      const end = html.indexOf('>', i);
+      if (end < 0) {
+        // Malformed: no closing '>'. Treat the rest as text rather
+        // than dropping it.
+        out += html.slice(i);
+        break;
+      }
+      const name = tagNameOf(html.slice(i + 1, end));
+      // Layout substitutions for the structural tags Wiktionary-style
+      // dicts use. Other tags (i, b, span, font, …) drop, content stays.
+      if (name === 'br') {
+        out += '\n';
+      } else if (name === 'li' && !html.slice(i + 1, end).trim().startsWith('/')) {
+        // Opening <li>: introduce a bullet on its own line.
+        out += '\n• ';
+      } else if (name === 'p' && !html.slice(i + 1, end).trim().startsWith('/')) {
+        // Opening <p>: paragraph break.
+        out += '\n\n';
+      }
+      // /li, /ol, /ul, ol, ul, /p, and all unknown tags: no output.
+      i = end + 1;
+    } else if (ch === '&') {
+      const semi = html.indexOf(';', i);
+      // Entity references are short. If we can't find a ';' within
+      // 20 chars, treat the '&' as literal. The limit covers long
+      // numeric entities (`&#1234567890;`) and verbose-but-reasonable
+      // named ones; anything longer is almost certainly not an entity.
+      if (semi < 0 || semi - i > 20) {
+        out += '&';
+        i++;
+      } else {
+        out += decodeEntity(html.slice(i + 1, semi));
+        i = semi + 1;
+      }
+    } else {
+      out += ch;
+      i++;
+    }
+  }
+  // Tidy: collapse runs of inline whitespace and any multi-newline
+  // sequence to a single newline. This produces tight output where
+  // each visible line is either a label, a bullet, or a paragraph —
+  // matching what users actually want for definition rendering. A
+  // <br> immediately followed by <li> shouldn't waste a blank line.
+  return out
+    .replace(/[ \t]+/g, ' ')
+    .replace(/ ?\n ?/g, '\n')
+    .replace(/\n{2,}/g, '\n')
+    .trim();
+};


### PR DESCRIPTION
## Summary

Two fixes that go together. They emerged from real on-device testing with a Hindi-English Wiktionary dict where the user wrote 'Namaste' and saw 'no definition found.'

- **`.syn` synonym index parsing.** Wiktionary-derived StarDicts keep native-script headwords (e.g. \`नमस्ते\`) in \`.idx\` and Latin transliterations (e.g. \`namaste\`) in \`.syn\`. Without reading \`.syn\`, the cross-script lookup misses entirely. We now parse \`.syn\` and merge it into the same lookup Map, all pointing at the canonical \`.idx\` entry.
- **HTML → plain text** for definitions with \`sametypesequence=h\`. Wiktionary dicts ship HTML inside each definition body. Our popup was rendering raw \`<i>\`/\`<br>\`/\`<ol>\`/\`<li>\` tags on screen instead of formatted text. New \`htmlToPlainText\` helper handles whitelist-based tag substitution, named + numeric entity decoding, and is idempotent on plain text so WordNet output is unchanged.

## On-device validation (informed this PR)

| Step | Before this PR | After |
|---|---|---|
| Lookup of \`Namaste\` against the Hindi dict | 'No definition found' (the dict's .idx is Devanagari-only; .syn was ignored) | Resolves via \`.syn\` to \`नमस्ते\` and shows the entry |
| Rendering of the resolved definition | Raw HTML (\`<i>intj</i><br><ol><li>A salutation...\`) | \`intj\\n• A salutation...\\nnoun\\n• greeting...\` |

Screenshot of the original raw-HTML render is in the conversation history; both fixes were validated against the same Hindi-English Wiktionary fixture from \`Vuizur/Wiktionary-Dictionaries\`.

## Architecture notes

- \`parseSyn.ts\` mirrors \`parseIdx.ts\`'s walk. Each \`.syn\` record is \`word_utf8 \\0 original_word_index_u32_be\`.
- \`buildDict\` takes an optional 4th \`synBytes\` arg. Out-of-range synonym indexes are skipped silently (a stray bad pointer doesn't dead-end the whole dict). Synonym keys never shadow existing \`.idx\` keys (idx wins on collision).
- \`userDictDiscovery\` detects a \`.syn\` next to the StarDict triple, fetches it via the same \`fetch(file://...)\` path, and treats a \`.syn\` fetch failure as non-fatal — the dict still loads with \`.idx\`-only behaviour and a warn log.
- \`htmlToPlainText\` is single-pass, no DOMParser, no regex over the whole string. \`<br>\` → newline, \`<li>\` → bulleted line, all other tags drop content-keeping. Named entities (\`&amp;\`, \`&lt;\`, \`&nbsp;\`, etc.) and numeric entities (decimal + hex) decode. Malformed unclosed tags pass through as literal text. The function short-circuits when neither \`<\` nor \`&\` is present, so genuinely-plain definitions cost zero work.
- \`DefinitionPopup\` routes only the WordNet-fallback render through the converter. The WordNet path is byte-identical to before.

## Coverage

- **310 / 310** tests pass (was 287).
- Coverage **99.56%** statements / **97.58%** branches — above the 97% bar required by \`CLAUDE.md\`.
- New test files:
  - \`__tests__/parseSyn.test.ts\` — 7 tests
  - \`__tests__/htmlToPlainText.test.ts\` — 23 tests
- Extended:
  - \`__tests__/stardictDict.test.ts\` — 7 new synonym-merge tests
  - \`__tests__/userDictDiscovery.test.ts\` — 3 new \`.syn\` discovery + soft-fail tests

## What this is NOT

- **No version bump in this PR.** CI handles release versioning; \`package.json\` and \`PluginConfig.json\` are untouched.
- **No change to the multi-source registry contract**, the popup's multi-section badge UX, or the bundled WordNet path.
- **No new runtime dependencies.** Pure JS additions.
- **MDX is still deferred** (separate licence problem; unchanged by this PR).

## Known limits worth flagging

- The HTML stripper is a *layout-and-text* cleaner, not a rich renderer. \`<i>\` markup is dropped; a future improvement could surface italics as a styled \`<Text>\` block, but that would mean reworking the popup's WordNet-vs-fallback branching and isn't in scope here.
- The \`.syn\` mapping unlocks Latin-transliteration lookups for dicts that ship one (Vuizur Wiktionary dicts do, ~2,619 pure-ASCII synonyms in the Hindi case). It does NOT match transliteration variants — \`swagat\` won't find \`svāgat\` because the dict uses IAST with diacritics. A diacritic-stripping pass would unlock another ~70× more matches; flagged as a follow-up.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npx jest\` — 310 / 310 pass
- [x] \`npx jest --coverage\` — ≥97% branches
- [x] On-device build with the Hindi-English Wiktionary dict at \`MyStyle/SnDict/sn-hindi-english/\` shows the \`Namaste\` lookup resolving via \`.syn\` to \`नमस्ते\` (logcat: \`[discovery] discovered 2 user dict(s): [Hindhi English Wiktionary, Tech Jargon]\`)
- [x] Popup body renders cleanly with bulleted POS-grouped senses, no leaked HTML tags
- [x] Bundled WordNet behaviour byte-identical to v1.0.2 (no \`.syn\`, no HTML, the WordNet parser path runs first and unchanged)