### PR TITLE
refactor: code quality hardening (issues #1, #6, #7, #8)

### DIFF
--- a/__tests__/DefinitionPopup.test.tsx
+++ b/__tests__/DefinitionPopup.test.tsx
@@ -24,7 +24,7 @@ import {
   hideDefinition,
   __testing__,
 } from '../src/ui/popupController';
-import type {LookupResult} from '../src/core/lookup';
+import type {DefinitionFormat, LookupResult} from '../src/core/lookup';
 
 const closePluginView = PluginManager.closePluginView as jest.Mock;
 
@@ -32,9 +32,10 @@ const found = (
   source: string,
   word: string,
   definition: string,
+  format: DefinitionFormat = 'plain',
 ): LookupResult => ({
   queriedFor: word,
-  hits: [{source, entry: {word, definition}}],
+  hits: [{source, entry: {word, definition, format}}],
 });
 
 const notFound = (queriedFor: string): LookupResult => ({
@@ -136,6 +137,48 @@ describe('DefinitionPopup', () => {
     expect(closePluginView).toHaveBeenCalledTimes(1);
   });
 
+  test('format=html: HTML tags get stripped to readable plain text', () => {
+    const tree = renderPopup();
+    act(() => {
+      showDefinition(
+        found(
+          'WikDict',
+          'namaste',
+          '<i>intj</i><br><ol><li>A salutation</li></ol>',
+          'html',
+        ),
+        'OCR: namaste',
+      );
+    });
+    const text = collectText(tree);
+    // Tags stripped, layout preserved as bullet/newline.
+    expect(text).not.toMatch(/<\/?[a-z]/i);
+    expect(text).toContain('intj');
+    expect(text).toContain('• A salutation');
+  });
+
+  test('format=plain: definition renders verbatim (no parser, no strip)', () => {
+    const tree = renderPopup();
+    // Deliberately HTML-looking content with format=plain — the
+    // popup must NOT strip it because the source declared plain.
+    const literal = '<not stripped> because format is plain';
+    act(() => {
+      showDefinition(found('Custom', 'x', literal, 'plain'));
+    });
+    expect(collectText(tree)).toContain(literal);
+  });
+
+  test('format=wordnet but body is unparseable: falls back to plain rendering', () => {
+    // A source can declare 'wordnet' but ship a body that doesn't
+    // match the WordNet shape (e.g. an empty entry). The popup
+    // shouldn't drop the content; it should render the raw string.
+    const tree = renderPopup();
+    act(() => {
+      showDefinition(found('Custom', 'x', 'a single line', 'wordnet'));
+    });
+    expect(collectText(tree)).toContain('a single line');
+  });
+
   test('renders parsed WordNet senses with POS labels, examples, synonyms', () => {
     const tree = renderPopup();
     const aiEntry =
@@ -147,7 +190,7 @@ describe('DefinitionPopup', () => {
       '"workers in AI hope to imitate intelligence" ' +
       '[syn: {artificial intelligence}]';
     act(() => {
-      showDefinition(found('WordNet', 'AI', aiEntry), 'OCR: AI');
+      showDefinition(found('WordNet', 'AI', aiEntry, 'wordnet'), 'OCR: AI');
     });
     const text = collectText(tree);
     expect(text).toContain('Army Intelligence');

--- a/__tests__/_helpers/inMemoryVfs.ts
+++ b/__tests__/_helpers/inMemoryVfs.ts
@@ -1,0 +1,84 @@
+// Shared in-memory virtual-filesystem helper for tests that need
+// real `discoverUserDicts` running against a controlled file layout.
+// Used by both the discovery unit tests and the end-to-end
+// integration test.
+
+import type {
+  FileEntry,
+  FileUtilsLike,
+} from '../../src/core/dict/userDictDiscovery';
+
+// Mapping path -> contents. A value of `'dir'` makes the path an
+// explicitly-empty directory (otherwise directories are inferred
+// from the presence of files under them).
+export type Vfs = Record<string, ArrayBuffer | 'dir'>;
+
+const fileEntry = (path: string, type: 0 | 1): FileEntry => ({path, type});
+
+export const makeVfs = (
+  entries: Vfs,
+): {fileUtils: FileUtilsLike; fetchFn: typeof fetch} => {
+  const childrenOf = (dir: string): FileEntry[] => {
+    const prefix = dir.endsWith('/') ? dir : dir + '/';
+    const seen = new Set<string>();
+    const out: FileEntry[] = [];
+    for (const path of Object.keys(entries)) {
+      if (!path.startsWith(prefix)) {
+        continue;
+      }
+      const tail = path.slice(prefix.length);
+      const slash = tail.indexOf('/');
+      const childName = slash < 0 ? tail : tail.slice(0, slash);
+      if (childName.length === 0 || seen.has(childName)) {
+        continue;
+      }
+      seen.add(childName);
+      const childPath = prefix + childName;
+      const isDir =
+        entries[childPath] === 'dir' ||
+        Object.keys(entries).some(
+          p => p !== childPath && p.startsWith(childPath + '/'),
+        );
+      out.push(fileEntry(childPath, isDir ? 0 : 1));
+    }
+    return out;
+  };
+  const fileUtils: FileUtilsLike = {
+    exists: jest.fn(async path => path in entries),
+    listFiles: jest.fn(async path => {
+      if (
+        !(path in entries) &&
+        !Object.keys(entries).some(p => p.startsWith(path + '/'))
+      ) {
+        throw new Error('Dir is not exists');
+      }
+      return childrenOf(path);
+    }),
+  };
+  const fetchFn = jest.fn(async (url: string) => {
+    const path = url.replace(/^file:\/\//, '');
+    const data = entries[path];
+    if (data === undefined || data === 'dir') {
+      return {
+        ok: false,
+        status: 404,
+        arrayBuffer: async () => new ArrayBuffer(0),
+      } as unknown as Response;
+    }
+    return {
+      ok: true,
+      status: 200,
+      arrayBuffer: async () => data,
+    } as unknown as Response;
+  });
+  return {fileUtils, fetchFn: fetchFn as unknown as typeof fetch};
+};
+
+export const enc = (s: string): ArrayBuffer =>
+  new TextEncoder().encode(s).buffer as ArrayBuffer;
+
+export const u8ToArrayBuffer = (u8: Uint8Array): ArrayBuffer =>
+  u8.buffer.slice(
+    u8.byteOffset,
+    u8.byteOffset + u8.byteLength,
+  ) as ArrayBuffer;

--- a/__tests__/csvDictSource.test.ts
+++ b/__tests__/csvDictSource.test.ts
@@ -15,14 +15,17 @@ describe('createCsvDictSource', () => {
     expect(await src.lookup('apple')).toEqual({
       word: 'apple',
       definition: 'a fruit',
+      format: 'plain',
     });
     expect(await src.lookup('banana')).toEqual({
       word: 'Banana',
       definition: 'a yellow fruit',
+      format: 'plain',
     });
     expect(await src.lookup('BANANA')).toEqual({
       word: 'Banana',
       definition: 'a yellow fruit',
+      format: 'plain',
     });
   });
 
@@ -93,7 +96,7 @@ describe('createCsvDictSource', () => {
   test('missing definition column yields empty string', async () => {
     const src = fromCsv('apple\n');
     const hit = await src.lookup('apple');
-    expect(hit).toEqual({word: 'apple', definition: ''});
+    expect(hit).toEqual({word: 'apple', definition: '', format: 'plain'});
   });
 
   test('returns null on empty input', async () => {

--- a/__tests__/end-to-end.test.tsx
+++ b/__tests__/end-to-end.test.tsx
@@ -1,0 +1,276 @@
+// End-to-end integration test wiring the real production modules
+// together over an in-memory filesystem and a react-test-renderer
+// popup. Catches the class of bug that unit tests miss — gaps
+// between layers, not gaps inside layers.
+//
+// Examples this test file would have caught:
+//   - The v1.0.2 ".syn was being ignored" bug. Unit tests for parsers
+//     and the registry both passed; the missing wire was invisible
+//     until a real dict loaded on a real device.
+//   - The "in-flight mutation race" the reviewer caught pre-merge.
+//     Reproducible here without a real plugin host.
+
+jest.mock('react-native', () => ({
+  View: 'View',
+  Text: 'Text',
+  ScrollView: 'ScrollView',
+  Pressable: 'Pressable',
+  StyleSheet: {create: (s: unknown) => s},
+}));
+
+jest.mock('sn-plugin-lib', () => ({
+  PluginManager: {closePluginView: jest.fn(() => Promise.resolve(true))},
+}));
+
+import React from 'react';
+import {act, create, type ReactTestRenderer} from 'react-test-renderer';
+import DefinitionPopup from '../src/ui/DefinitionPopup';
+import {
+  showDefinition,
+  __testing__,
+} from '../src/ui/popupController';
+import {createMultiDictLookup} from '../src/core/dict/multiDictLookup';
+import {createStardictLookup} from '../src/core/dict/stardictLookup';
+import {createCsvDictSource} from '../src/core/dict/csvDictSource';
+import {discoverUserDicts} from '../src/core/dict/userDictDiscovery';
+import type {DictSource} from '../src/core/lookup';
+import {buildSyntheticStarDict} from './_helpers/buildSyntheticStarDict';
+import {enc, makeVfs, u8ToArrayBuffer} from './_helpers/inMemoryVfs';
+
+const ROOT = '/storage/emulated/0/MyStyle/SnDict';
+
+const renderPopup = (): ReactTestRenderer => {
+  let tree!: ReactTestRenderer;
+  act(() => {
+    tree = create(<DefinitionPopup />);
+  });
+  return tree;
+};
+
+const collectText = (tree: ReactTestRenderer): string => {
+  const acc: string[] = [];
+  const visit = (node: unknown): void => {
+    if (typeof node === 'string') {
+      acc.push(node);
+      return;
+    }
+    if (Array.isArray(node)) {
+      node.forEach(visit);
+      return;
+    }
+    if (node && typeof node === 'object' && 'children' in node) {
+      visit((node as {children: unknown}).children);
+    }
+  };
+  visit(tree.toJSON());
+  return acc.join(' | ');
+};
+
+const stardictBuffers = (entries: Record<string, string>) => {
+  const triple = buildSyntheticStarDict(entries, {gzipDict: true});
+  return {
+    ifo: u8ToArrayBuffer(triple.ifo),
+    idx: u8ToArrayBuffer(triple.idx),
+    dict: u8ToArrayBuffer(triple.dict),
+  };
+};
+
+beforeEach(() => {
+  __testing__.reset();
+});
+
+describe('end-to-end (discovery → registry → popup)', () => {
+  test('user-dropped CSV becomes a popup section after lookup', async () => {
+    const vfs = makeVfs({
+      [`${ROOT}/medical/words.csv`]: enc('apple,a fruit\n'),
+    });
+    // 1. Real discovery against the VFS.
+    const userDicts = await discoverUserDicts({
+      fileUtils: vfs.fileUtils,
+      fetchFn: vfs.fetchFn,
+      rootPath: ROOT,
+    });
+    // 2. Real registry composition.
+    const lookup = createMultiDictLookup(userDicts);
+    // 3. Real popup mounting.
+    const tree = renderPopup();
+    // 4. Real lookup → controller emit → popup render.
+    const result = await lookup.lookup('apple');
+    act(() => {
+      showDefinition(result);
+    });
+    // 5. Popup tree contains the definition.
+    const text = collectText(tree);
+    expect(text).toContain('apple');
+    expect(text).toContain('a fruit');
+  });
+
+  test('multi-source rendering: both dicts hit, popup shows both sections with badges', async () => {
+    const baseTriple = stardictBuffers({apple: 'a fruit (base)'});
+    const vfs = makeVfs({
+      [`${ROOT}/custom/data.csv`]: enc('apple,a fruit (custom)\n'),
+    });
+    const userDicts = await discoverUserDicts({
+      fileUtils: vfs.fileUtils,
+      fetchFn: vfs.fetchFn,
+      rootPath: ROOT,
+    });
+    const baseSource: DictSource = createStardictLookup({
+      name: 'WordNet',
+      loadBase: async () => ({
+        ifo: new Uint8Array(baseTriple.ifo),
+        idx: new Uint8Array(baseTriple.idx),
+        dict: new Uint8Array(baseTriple.dict),
+      }),
+    });
+    const lookup = createMultiDictLookup([...userDicts, baseSource]);
+    const tree = renderPopup();
+    const result = await lookup.lookup('apple');
+    act(() => {
+      showDefinition(result);
+    });
+    const text = collectText(tree);
+    // Both definitions render.
+    expect(text).toContain('a fruit (custom)');
+    expect(text).toContain('a fruit (base)');
+    // Source badges appear because there are ≥2 hits.
+    expect(text).toContain('custom');
+    expect(text).toContain('WordNet');
+  });
+
+  test('not-found: lookup misses every source; popup shows the not-found message', async () => {
+    const userDicts = [
+      createCsvDictSource({
+        name: 'A',
+        loadBytes: async () => enc('apple,fruit\n'),
+      }),
+    ];
+    const lookup = createMultiDictLookup(userDicts);
+    const tree = renderPopup();
+    const result = await lookup.lookup('xyzzy');
+    act(() => {
+      showDefinition(result);
+    });
+    expect(collectText(tree)).toMatch(/no definition found/i);
+  });
+
+  test('StarDict with .syn: latin transliteration resolves to native-script entry', async () => {
+    // Builds the same kind of cross-script lookup as the real
+    // Wiktionary Hindi-English dict (Devanagari headwords + Latin
+    // transliteration synonyms). Verifies the .syn fix end-to-end.
+    const triple = buildSyntheticStarDict({
+      'नमस्ते': 'a Hindi greeting',
+    });
+    // Hand-build a .syn pointing 'namaste' at idx[0] (the only entry).
+    const synBytes = new Uint8Array([
+      0x6e, 0x61, 0x6d, 0x61, 0x73, 0x74, 0x65, // 'namaste'
+      0,
+      0, 0, 0, 0, // index 0, big-endian u32
+    ]);
+    const vfs = makeVfs({
+      [`${ROOT}/hindi/dict.ifo`]: u8ToArrayBuffer(triple.ifo),
+      [`${ROOT}/hindi/dict.idx`]: u8ToArrayBuffer(triple.idx),
+      [`${ROOT}/hindi/dict.dict.dz`]: u8ToArrayBuffer(triple.dict),
+      [`${ROOT}/hindi/dict.syn`]: u8ToArrayBuffer(synBytes),
+    });
+    const userDicts = await discoverUserDicts({
+      fileUtils: vfs.fileUtils,
+      fetchFn: vfs.fetchFn,
+      rootPath: ROOT,
+    });
+    const lookup = createMultiDictLookup(userDicts);
+    const tree = renderPopup();
+    const result = await lookup.lookup('namaste');
+    act(() => {
+      showDefinition(result);
+    });
+    const text = collectText(tree);
+    // The popup header renders the canonical Devanagari word, not
+    // the latin synonym alias.
+    expect(text).toContain('नमस्ते');
+    // And the definition body of the canonical entry.
+    expect(text).toContain('a Hindi greeting');
+  });
+
+  test('HTML-formatted StarDict: tags are stripped end-to-end', async () => {
+    // Mimics a Wiktionary-derived StarDict whose .ifo declares
+    // sametypesequence=h. Discovery -> source picks format='html' ->
+    // popup runs htmlToPlainText. No tags should leak.
+    const triple = buildSyntheticStarDict(
+      {hello: '<i>intj</i><br><ol><li>greeting</li></ol>'},
+      {sametypesequence: 'h'},
+    );
+    const vfs = makeVfs({
+      [`${ROOT}/wikt/d.ifo`]: u8ToArrayBuffer(triple.ifo),
+      [`${ROOT}/wikt/d.idx`]: u8ToArrayBuffer(triple.idx),
+      [`${ROOT}/wikt/d.dict`]: u8ToArrayBuffer(triple.dict),
+    });
+    const userDicts = await discoverUserDicts({
+      fileUtils: vfs.fileUtils,
+      fetchFn: vfs.fetchFn,
+      rootPath: ROOT,
+    });
+    const lookup = createMultiDictLookup(userDicts);
+    const tree = renderPopup();
+    const result = await lookup.lookup('hello');
+    act(() => {
+      showDefinition(result);
+    });
+    const text = collectText(tree);
+    expect(text).not.toMatch(/<\/?[a-z]/i);
+    expect(text).toContain('intj');
+    expect(text).toContain('• greeting');
+  });
+
+  test('mid-flight discovery prepend does not break in-flight lookups (regression)', async () => {
+    // Models the index.js startup wiring: a shared sources array
+    // that gets mutated when discovery completes. Verifies the
+    // in-flight lookup snapshot semantics that the reviewer caught
+    // pre-merge of v1.0.2.
+    const vfs = makeVfs({
+      [`${ROOT}/extra/words.csv`]: enc('apple,fruit (extra)\n'),
+    });
+    // Slow base source so the in-flight lookup is still going when
+    // we mutate.
+    const slowBase: DictSource = {
+      name: 'Base',
+      lookup: jest.fn(
+        () =>
+          new Promise(resolve =>
+            setTimeout(
+              () => resolve({word: 'apple', definition: 'fruit (base)', format: 'plain'}),
+              25,
+            ),
+          ),
+      ),
+    };
+    const sources: DictSource[] = [slowBase];
+    const lookup = createMultiDictLookup(sources);
+
+    // Kick off the lookup before discovery completes...
+    const inFlight = lookup.lookup('apple');
+    // ...then prepend the discovered user dict, the way index.js does.
+    const userDicts = await discoverUserDicts({
+      fileUtils: vfs.fileUtils,
+      fetchFn: vfs.fetchFn,
+      rootPath: ROOT,
+    });
+    sources.unshift(...userDicts);
+
+    const result = await inFlight;
+    // The in-flight lookup must observe ONLY the sources present
+    // at its start (the slow base). No undefined entries leak.
+    expect(result.hits).toEqual([
+      {source: 'Base', entry: {word: 'apple', definition: 'fruit (base)', format: 'plain'}},
+    ]);
+    for (const hit of result.hits) {
+      expect(hit.entry).toBeDefined();
+      expect(typeof hit.entry.definition).toBe('string');
+    }
+
+    // The next lookup picks up the prepended user dict.
+    const next = await lookup.lookup('apple');
+    expect(next.hits.length).toBe(2);
+    expect(next.hits[0].source).toBe('extra');
+  });
+});

--- a/__tests__/jsonDictSource.test.ts
+++ b/__tests__/jsonDictSource.test.ts
@@ -13,10 +13,12 @@ describe('createJsonDictSource', () => {
     expect(await src.lookup('apple')).toEqual({
       word: 'apple',
       definition: 'a fruit',
+      format: 'plain',
     });
     expect(await src.lookup('banana')).toEqual({
       word: 'banana',
       definition: 'a yellow fruit',
+      format: 'plain',
     });
   });
 
@@ -49,6 +51,7 @@ describe('createJsonDictSource', () => {
     expect(await src.lookup('banana')).toEqual({
       word: 'Banana',
       definition: 'a yellow fruit',
+      format: 'plain',
     });
   });
 

--- a/__tests__/lazyAsyncSource.test.ts
+++ b/__tests__/lazyAsyncSource.test.ts
@@ -1,38 +1,38 @@
 import {createLazyAsyncSource} from '../src/core/dict/lazyAsyncSource';
 import type {DictEntry} from '../src/core/lookup';
 
-const enc = (s: string) => new TextEncoder().encode(s).buffer;
+const enc = (s: string) => new TextEncoder().encode(s);
+
+const decodeMap = (bytes: Uint8Array): Map<string, string> => {
+  const m = new Map<string, string>();
+  new TextDecoder().decode(bytes).split('\n').forEach(line => {
+    const [w, d] = line.split('|');
+    if (w && d) {
+      m.set(w.toLowerCase(), d);
+    }
+  });
+  return m;
+};
 
 const buildDeps = (overrides: {
-  loadBytes?: () => Promise<ArrayBuffer | null>;
+  load?: () => Promise<Uint8Array | null>;
   parse?: (bytes: Uint8Array) => Map<string, string>;
   lookup?: (parsed: Map<string, string>, word: string) => DictEntry | null;
-  maxBytes?: number;
+  logTag?: string;
   logger?: {warn: jest.Mock};
 } = {}) => {
   const logger = overrides.logger ?? {warn: jest.fn()};
   return {
     name: 'test',
-    loadBytes: overrides.loadBytes ?? (async () => enc('apple|fruit\nbanana|yellow')),
-    parse:
-      overrides.parse ??
-      ((bytes: Uint8Array) => {
-        const m = new Map<string, string>();
-        new TextDecoder().decode(bytes).split('\n').forEach(line => {
-          const [w, d] = line.split('|');
-          if (w && d) {
-            m.set(w.toLowerCase(), d);
-          }
-        });
-        return m;
-      }),
+    logTag: overrides.logTag,
+    load: overrides.load ?? (async () => enc('apple|fruit\nbanana|yellow')),
+    parse: overrides.parse ?? decodeMap,
     lookup:
       overrides.lookup ??
       ((parsed: Map<string, string>, word: string) => {
         const def = parsed.get(word.toLowerCase());
         return def ? {word, definition: def} : null;
       }),
-    maxBytes: overrides.maxBytes,
     logger,
   };
 };
@@ -40,7 +40,7 @@ const buildDeps = (overrides: {
 describe('createLazyAsyncSource', () => {
   test('lazy-loads on first lookup; further lookups reuse the parsed dict', async () => {
     const deps = buildDeps();
-    const loadSpy = jest.spyOn(deps, 'loadBytes');
+    const loadSpy = jest.spyOn(deps, 'load');
     const source = createLazyAsyncSource(deps);
     expect(loadSpy).not.toHaveBeenCalled();
     const a = await source.lookup('apple');
@@ -52,7 +52,7 @@ describe('createLazyAsyncSource', () => {
 
   test('returns null for empty / whitespace input without invoking the loader', async () => {
     const deps = buildDeps();
-    const loadSpy = jest.spyOn(deps, 'loadBytes');
+    const loadSpy = jest.spyOn(deps, 'load');
     const source = createLazyAsyncSource(deps);
     expect(await source.lookup('  ')).toBeNull();
     expect(loadSpy).not.toHaveBeenCalled();
@@ -62,7 +62,7 @@ describe('createLazyAsyncSource', () => {
     let calls = 0;
     const source = createLazyAsyncSource(
       buildDeps({
-        loadBytes: async () => {
+        load: async () => {
           calls++;
           return null;
         },
@@ -83,7 +83,9 @@ describe('createLazyAsyncSource', () => {
       return enc('apple|fruit');
     };
     const warn = jest.fn();
-    const source = createLazyAsyncSource(buildDeps({loadBytes: flaky, logger: {warn}}));
+    const source = createLazyAsyncSource(
+      buildDeps({load: flaky, logger: {warn}}),
+    );
     expect(await source.lookup('apple')).toBeNull();
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('loader threw: flaky'));
     expect(await source.lookup('apple')).toEqual({word: 'apple', definition: 'fruit'});
@@ -110,18 +112,36 @@ describe('createLazyAsyncSource', () => {
     expect(await source.lookup('apple')).toEqual({word: 'apple', definition: 'fruit'});
   });
 
-  test('refuses files larger than maxBytes (warns, returns null)', async () => {
+  test('logTag overrides the default name in warn messages', async () => {
     const warn = jest.fn();
     const source = createLazyAsyncSource(
       buildDeps({
-        loadBytes: async () => new ArrayBuffer(100),
-        maxBytes: 50,
+        load: async () => {
+          throw new Error('boom');
+        },
+        logTag: 'stardict:WordNet',
         logger: {warn},
       }),
     );
-    expect(await source.lookup('apple')).toBeNull();
+    await source.lookup('apple');
     expect(warn).toHaveBeenCalledWith(
-      expect.stringMatching(/file too large: 100 bytes > 50 cap/),
+      expect.stringMatching(/^\[stardict:WordNet] loader threw/),
+    );
+  });
+
+  test('default tag falls back to the source name', async () => {
+    const warn = jest.fn();
+    const source = createLazyAsyncSource(
+      buildDeps({
+        load: async () => {
+          throw new Error('boom');
+        },
+        logger: {warn},
+      }),
+    );
+    await source.lookup('apple');
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringMatching(/^\[test] loader threw/),
     );
   });
 
@@ -129,21 +149,14 @@ describe('createLazyAsyncSource', () => {
     let parseCalls = 0;
     const parse = (bytes: Uint8Array) => {
       parseCalls++;
-      const m = new Map<string, string>();
-      new TextDecoder().decode(bytes).split('\n').forEach(line => {
-        const [w, d] = line.split('|');
-        if (w && d) {
-          m.set(w.toLowerCase(), d);
-        }
-      });
-      return m;
+      return decodeMap(bytes);
     };
     let loadCalls = 0;
-    const loadBytes = async () => {
+    const load = async () => {
       loadCalls++;
       return enc('apple|fruit\nbanana|yellow');
     };
-    const source = createLazyAsyncSource(buildDeps({loadBytes, parse}));
+    const source = createLazyAsyncSource(buildDeps({load, parse}));
     const [a, b, c] = await Promise.all([
       source.lookup('apple'),
       source.lookup('banana'),
@@ -159,12 +172,40 @@ describe('createLazyAsyncSource', () => {
   test('survives without a logger when the loader throws', async () => {
     const source = createLazyAsyncSource(
       buildDeps({
-        loadBytes: async () => {
+        load: async () => {
           throw new Error('silent');
         },
         logger: undefined,
       }),
     );
     expect(await source.lookup('apple')).toBeNull();
+  });
+
+  test('works with a non-byte TLoaded (e.g. a struct of buffers like StarDict)', async () => {
+    // Verifies the helper is truly generic over TLoaded — the
+    // primary motivation for the unification refactor.
+    type Triple = {a: Uint8Array; b: Uint8Array};
+    const source = createLazyAsyncSource<Triple, Map<string, string>>({
+      name: 'composite',
+      load: async () => ({
+        a: enc('apple|fruit'),
+        b: enc('banana|yellow'),
+      }),
+      parse: triple => {
+        const merged = new Map<string, string>();
+        for (const part of [triple.a, triple.b]) {
+          for (const [k, v] of decodeMap(part)) {
+            merged.set(k, v);
+          }
+        }
+        return merged;
+      },
+      lookup: (parsed, word) => {
+        const def = parsed.get(word.toLowerCase());
+        return def ? {word, definition: def} : null;
+      },
+    });
+    expect((await source.lookup('apple'))?.definition).toBe('fruit');
+    expect((await source.lookup('banana'))?.definition).toBe('yellow');
   });
 });

--- a/__tests__/stardictLookup.test.ts
+++ b/__tests__/stardictLookup.test.ts
@@ -74,7 +74,7 @@ describe('createStardictLookup (DictSource)', () => {
     });
     expect(await source.lookup('apple')).toBeNull();
     expect(warn).toHaveBeenCalledWith(
-      expect.stringMatching(/stardict:WordNet.*buildDict threw/),
+      expect.stringMatching(/stardict:WordNet.*parse threw/),
     );
   });
 

--- a/__tests__/stardictLookup.test.ts
+++ b/__tests__/stardictLookup.test.ts
@@ -16,7 +16,11 @@ describe('createStardictLookup (DictSource)', () => {
   test('finds words from the loaded dict (returns DictEntry)', async () => {
     const source = createStardictLookup({name: 'WordNet', loadBase: baseBytes});
     const entry = await source.lookup('apple');
-    expect(entry).toEqual({word: 'apple', definition: 'a fruit (base)'});
+    expect(entry).toEqual({
+      word: 'apple',
+      definition: 'a fruit (base)',
+      format: 'plain',
+    });
   });
 
   test('returns null for an unknown word', async () => {
@@ -104,6 +108,7 @@ describe('createStardictLookup (DictSource)', () => {
     expect(await source.lookup('apple')).toEqual({
       word: 'apple',
       definition: 'a fruit (base)',
+      format: 'plain',
     });
     expect(flaky).toHaveBeenCalledTimes(2);
   });
@@ -143,6 +148,36 @@ describe('createStardictLookup (DictSource)', () => {
     expect(b?.definition).toBe('a yellow fruit (base)');
     expect(c?.definition).toBe('a fruit (base)');
     expect(calls).toBe(1);
+  });
+
+  test('derives format=html from .ifo sametypesequence=h', async () => {
+    const htmlBytes = async () =>
+      buildSyntheticStarDict(
+        {apple: '<i>n</i> a fruit'},
+        {sametypesequence: 'h'},
+      );
+    const source = createStardictLookup({
+      name: 'WordNet',
+      loadBase: htmlBytes,
+    });
+    const entry = await source.lookup('apple');
+    expect(entry).toEqual({
+      word: 'apple',
+      definition: '<i>n</i> a fruit',
+      format: 'html',
+    });
+  });
+
+  test('explicit format option overrides the auto-derived one', async () => {
+    // The bundled WordNet base uses this so the popup runs the
+    // structured-sense renderer regardless of what the .ifo says.
+    const source = createStardictLookup({
+      name: 'WordNet',
+      loadBase: baseBytes,
+      format: 'wordnet',
+    });
+    const entry = await source.lookup('apple');
+    expect(entry?.format).toBe('wordnet');
   });
 
   test('does NOT retry when the loader intentionally returns null', async () => {

--- a/__tests__/userDictDiscovery.test.ts
+++ b/__tests__/userDictDiscovery.test.ts
@@ -214,6 +214,7 @@ describe('discoverUserDicts', () => {
     expect(await sources[0].lookup('apple')).toEqual({
       word: 'apple',
       definition: 'a fruit',
+      format: 'plain',
     });
   });
 

--- a/__tests__/userDictDiscovery.test.ts
+++ b/__tests__/userDictDiscovery.test.ts
@@ -5,72 +5,9 @@ import {
   type FileUtilsLike,
 } from '../src/core/dict/userDictDiscovery';
 import {buildSyntheticStarDict} from './_helpers/buildSyntheticStarDict';
-
-const enc = (s: string) => new TextEncoder().encode(s).buffer as ArrayBuffer;
+import {enc, makeVfs, type Vfs} from './_helpers/inMemoryVfs';
 
 const fileEntry = (path: string, type: 0 | 1): FileEntry => ({path, type});
-
-// In-memory virtual filesystem for the test. listFiles returns the
-// children of any directory; fetch resolves file:// URIs against the
-// same map.
-type Vfs = Record<string, ArrayBuffer | 'dir'>;
-
-const makeVfs = (entries: Vfs): {
-  fileUtils: FileUtilsLike;
-  fetchFn: typeof fetch;
-} => {
-  const childrenOf = (dir: string): FileEntry[] => {
-    const prefix = dir.endsWith('/') ? dir : dir + '/';
-    const seen = new Set<string>();
-    const out: FileEntry[] = [];
-    for (const path of Object.keys(entries)) {
-      if (!path.startsWith(prefix)) {
-        continue;
-      }
-      const tail = path.slice(prefix.length);
-      const slash = tail.indexOf('/');
-      const childName = slash < 0 ? tail : tail.slice(0, slash);
-      if (childName.length === 0 || seen.has(childName)) {
-        continue;
-      }
-      seen.add(childName);
-      const childPath = prefix + childName;
-      const isDir =
-        entries[childPath] === 'dir' ||
-        Object.keys(entries).some(p =>
-          p !== childPath && p.startsWith(childPath + '/'),
-        );
-      out.push(fileEntry(childPath, isDir ? 0 : 1));
-    }
-    return out;
-  };
-  const fileUtils: FileUtilsLike = {
-    exists: jest.fn(async path => path in entries),
-    listFiles: jest.fn(async path => {
-      if (!(path in entries) && !Object.keys(entries).some(p => p.startsWith(path + '/'))) {
-        throw new Error('Dir is not exists');
-      }
-      return childrenOf(path);
-    }),
-  };
-  const fetchFn = jest.fn(async (url: string) => {
-    const path = url.replace(/^file:\/\//, '');
-    const data = entries[path];
-    if (data === undefined || data === 'dir') {
-      return {
-        ok: false,
-        status: 404,
-        arrayBuffer: async () => new ArrayBuffer(0),
-      } as unknown as Response;
-    }
-    return {
-      ok: true,
-      status: 200,
-      arrayBuffer: async () => data,
-    } as unknown as Response;
-  });
-  return {fileUtils, fetchFn: fetchFn as unknown as typeof fetch};
-};
 
 const buildLogger = () => ({log: jest.fn(), warn: jest.fn()});
 

--- a/index.js
+++ b/index.js
@@ -34,10 +34,13 @@ const logger = {
 
 // The base dict source. Bundled into the JS at build time, so the
 // loader is sync underneath; we wrap it in async to fit the shared
-// loadBase contract used by runtime-discovered user dicts.
+// loadBase contract used by runtime-discovered user dicts. Explicit
+// format='wordnet' so the popup uses the structured-sense renderer
+// for entries from this source.
 const baseSource = createStardictLookup({
   name: 'WordNet',
   loadBase: async () => loadBaseDictFromGenerated(),
+  format: 'wordnet',
   logger,
 });
 

--- a/src/core/dict/csvDictSource.ts
+++ b/src/core/dict/csvDictSource.ts
@@ -6,7 +6,7 @@
 // Lookup is case-insensitive. First occurrence of a key wins (later
 // duplicates are ignored), matching StarDict's behaviour.
 
-import {decodeUtf8} from '../../sdk/utf8';
+import {decodeUtf8, stripBom} from '../../sdk/utf8';
 import type {DictEntry, DictSource} from '../lookup';
 import {createLazyAsyncSource} from './lazyAsyncSource';
 
@@ -28,9 +28,6 @@ export type CsvDictDeps = {
 };
 
 const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
-
-const stripBom = (s: string): string =>
-  s.charCodeAt(0) === 0xfeff ? s.slice(1) : s;
 
 // Minimal RFC 4180-style CSV row parser. Caller guarantees
 // `start < s.length`. Handles:

--- a/src/core/dict/csvDictSource.ts
+++ b/src/core/dict/csvDictSource.ts
@@ -8,7 +8,9 @@
 
 import {decodeUtf8} from '../../sdk/utf8';
 import type {DictEntry, DictSource} from '../lookup';
-import {createLazyAsyncSource, type LoadBytes} from './lazyAsyncSource';
+import {createLazyAsyncSource} from './lazyAsyncSource';
+
+export type LoadBytes = () => Promise<ArrayBuffer | null>;
 
 export type CsvDictDeps = {
   name: string;
@@ -132,16 +134,31 @@ const lookupCsv = (parsed: ParsedCsv, word: string): DictEntry | null => {
   return hit ? {word: hit.word, definition: hit.definition} : null;
 };
 
-export const createCsvDictSource = (deps: CsvDictDeps): DictSource =>
-  createLazyAsyncSource<ParsedCsv>({
+export const createCsvDictSource = (deps: CsvDictDeps): DictSource => {
+  const maxBytes = deps.maxBytes ?? DEFAULT_MAX_BYTES;
+  const parseCsv = buildCsv({
+    headwordCol: deps.headwordCol ?? 0,
+    definitionCol: deps.definitionCol ?? 1,
+    hasHeader: deps.hasHeader ?? false,
+  });
+  return createLazyAsyncSource<Uint8Array, ParsedCsv>({
     name: deps.name,
-    loadBytes: deps.loadBytes,
-    parse: buildCsv({
-      headwordCol: deps.headwordCol ?? 0,
-      definitionCol: deps.definitionCol ?? 1,
-      hasHeader: deps.hasHeader ?? false,
-    }),
+    load: async () => {
+      const buf = await deps.loadBytes();
+      if (buf === null) {
+        return null;
+      }
+      // Size cap is per-format (10 MB for CSV). The unified lazy
+      // helper is format-agnostic; the check belongs here.
+      if (buf.byteLength > maxBytes) {
+        throw new Error(
+          `file too large: ${buf.byteLength} bytes > ${maxBytes} cap`,
+        );
+      }
+      return new Uint8Array(buf);
+    },
+    parse: parseCsv,
     lookup: lookupCsv,
-    maxBytes: deps.maxBytes ?? DEFAULT_MAX_BYTES,
     logger: deps.logger,
   });
+};

--- a/src/core/dict/csvDictSource.ts
+++ b/src/core/dict/csvDictSource.ts
@@ -131,7 +131,9 @@ const buildCsv = (
 
 const lookupCsv = (parsed: ParsedCsv, word: string): DictEntry | null => {
   const hit = parsed.index.get(word.toLowerCase());
-  return hit ? {word: hit.word, definition: hit.definition} : null;
+  return hit
+    ? {word: hit.word, definition: hit.definition, format: 'plain'}
+    : null;
 };
 
 export const createCsvDictSource = (deps: CsvDictDeps): DictSource => {

--- a/src/core/dict/jsonDictSource.ts
+++ b/src/core/dict/jsonDictSource.ts
@@ -7,7 +7,7 @@
 //
 // Lookup is case-insensitive. First occurrence of a key wins.
 
-import {decodeUtf8} from '../../sdk/utf8';
+import {decodeUtf8, stripBom} from '../../sdk/utf8';
 import type {DictEntry, DictSource} from '../lookup';
 import {createLazyAsyncSource} from './lazyAsyncSource';
 import type {LoadBytes} from './csvDictSource';
@@ -25,9 +25,6 @@ const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
 type ParsedJson = {
   index: Map<string, {word: string; definition: string}>;
 };
-
-const stripBom = (s: string): string =>
-  s.charCodeAt(0) === 0xfeff ? s.slice(1) : s;
 
 const pickHeadword = (row: Record<string, unknown>): string | undefined => {
   const candidates = ['word', 'headword', 'term', 'key'];

--- a/src/core/dict/jsonDictSource.ts
+++ b/src/core/dict/jsonDictSource.ts
@@ -9,7 +9,8 @@
 
 import {decodeUtf8} from '../../sdk/utf8';
 import type {DictEntry, DictSource} from '../lookup';
-import {createLazyAsyncSource, type LoadBytes} from './lazyAsyncSource';
+import {createLazyAsyncSource} from './lazyAsyncSource';
+import type {LoadBytes} from './csvDictSource';
 
 export type JsonDictDeps = {
   name: string;
@@ -98,12 +99,26 @@ const lookupJson = (parsed: ParsedJson, word: string): DictEntry | null => {
   return hit ? {word: hit.word, definition: hit.definition} : null;
 };
 
-export const createJsonDictSource = (deps: JsonDictDeps): DictSource =>
-  createLazyAsyncSource<ParsedJson>({
+export const createJsonDictSource = (deps: JsonDictDeps): DictSource => {
+  const maxBytes = deps.maxBytes ?? DEFAULT_MAX_BYTES;
+  return createLazyAsyncSource<Uint8Array, ParsedJson>({
     name: deps.name,
-    loadBytes: deps.loadBytes,
+    load: async () => {
+      const buf = await deps.loadBytes();
+      if (buf === null) {
+        return null;
+      }
+      // Size cap is per-format (10 MB for JSON). The unified lazy
+      // helper is format-agnostic; the check belongs here.
+      if (buf.byteLength > maxBytes) {
+        throw new Error(
+          `file too large: ${buf.byteLength} bytes > ${maxBytes} cap`,
+        );
+      }
+      return new Uint8Array(buf);
+    },
     parse: buildJson,
     lookup: lookupJson,
-    maxBytes: deps.maxBytes ?? DEFAULT_MAX_BYTES,
     logger: deps.logger,
   });
+};

--- a/src/core/dict/jsonDictSource.ts
+++ b/src/core/dict/jsonDictSource.ts
@@ -96,7 +96,9 @@ const buildJson = (bytes: Uint8Array): ParsedJson => {
 
 const lookupJson = (parsed: ParsedJson, word: string): DictEntry | null => {
   const hit = parsed.index.get(word.toLowerCase());
-  return hit ? {word: hit.word, definition: hit.definition} : null;
+  return hit
+    ? {word: hit.word, definition: hit.definition, format: 'plain'}
+    : null;
 };
 
 export const createJsonDictSource = (deps: JsonDictDeps): DictSource => {

--- a/src/core/dict/lazyAsyncSource.ts
+++ b/src/core/dict/lazyAsyncSource.ts
@@ -1,63 +1,64 @@
-// Shared lazy-load + retry harness for async-loaded DictSources
-// (CSV, JSON, MDX). StarDict is sync-loaded (bundled bytes) and
-// uses its own helper in stardictLookup.ts.
+// Shared lazy-load + retry harness for any async-loaded DictSource.
+// One helper, regardless of whether the format loads a single byte
+// buffer (CSV, JSON) or a multi-buffer composite (StarDict's
+// {ifo, idx, dict, syn?}).
 //
 // Contract:
-//   - Loader returns null intentionally -> 'absent', sticks (no retry).
-//   - Loader / parser throws            -> 'failed', leaves loaded=false
-//                                          so the next lookup retries
-//                                          (transient errors must not
-//                                          permanently dead-end the
-//                                          session).
-//   - Loader returns bytes + parser ok  -> 'success', sticks.
+//   - load() returns null intentionally -> 'absent', sticks (no retry).
+//   - load() / parse() throws            -> 'failed', leaves the
+//                                           state empty so the next
+//                                           lookup retries (transient
+//                                           errors must not permanently
+//                                           dead-end the session).
+//   - load() returns + parse() ok        -> 'success', sticks.
 //
 // Concurrency: the load promise is memoised so concurrent first
 // lookups share one underlying load+parse pass instead of racing.
 
 import type {DictEntry, DictSource} from '../lookup';
 
-export type LoadBytes = () => Promise<ArrayBuffer | null>;
-
-export type LazyAsyncSourceDeps<TParsed> = {
+export type LazyAsyncSourceDeps<TLoaded, TParsed> = {
+  // Display name for the popup section label.
   name: string;
-  loadBytes: LoadBytes;
-  parse: (bytes: Uint8Array) => TParsed;
+  // Optional log-tag prefix for warn messages. Defaults to `name`.
+  // Existing StarDict logs read `[stardict:WordNet] ...` so the
+  // factory passes "stardict:WordNet" here while keeping `name`
+  // = "WordNet" for the popup.
+  logTag?: string;
+  // Loader: returns whatever the parser needs. Null = absent
+  // (deliberate opt-out); throwing = transient failure (will retry).
+  load: () => Promise<TLoaded | null>;
+  // Format-specific parse. Size caps and any other validation belong
+  // here — the harness is format-agnostic.
+  parse: (loaded: TLoaded) => TParsed;
+  // Format-specific lookup against the parsed dict.
   lookup: (parsed: TParsed, word: string) => DictEntry | null;
-  // Optional cap; throw before parse if the file is larger.
-  maxBytes?: number;
   logger?: {warn: (msg: string) => void};
 };
 
-export const createLazyAsyncSource = <TParsed>(
-  deps: LazyAsyncSourceDeps<TParsed>,
+export const createLazyAsyncSource = <TLoaded, TParsed>(
+  deps: LazyAsyncSourceDeps<TLoaded, TParsed>,
 ): DictSource => {
   const warn = deps.logger?.warn ?? (() => {});
-  const tag = deps.name;
+  const tag = deps.logTag ?? deps.name;
   let parsed: TParsed | null = null;
   let absent = false;
   let inFlight: Promise<void> | null = null;
 
   const doLoad = async (): Promise<void> => {
-    let buf: ArrayBuffer | null;
+    let loaded: TLoaded | null;
     try {
-      buf = await deps.loadBytes();
+      loaded = await deps.load();
     } catch (e) {
       warn(`[${tag}] loader threw: ${(e as Error).message}`);
       throw e;
     }
-    if (buf === null) {
+    if (loaded === null) {
       absent = true;
       return;
     }
-    if (deps.maxBytes !== undefined && buf.byteLength > deps.maxBytes) {
-      const e = new Error(
-        `file too large: ${buf.byteLength} bytes > ${deps.maxBytes} cap`,
-      );
-      warn(`[${tag}] ${e.message}`);
-      throw e;
-    }
     try {
-      parsed = deps.parse(new Uint8Array(buf));
+      parsed = deps.parse(loaded);
     } catch (e) {
       warn(`[${tag}] parse threw: ${(e as Error).message}`);
       throw e;

--- a/src/core/dict/stardict/writeStardict.ts
+++ b/src/core/dict/stardict/writeStardict.ts
@@ -33,6 +33,10 @@ export type WriteOptions = {
   // exercises the .dict.dz inflate path. Off by default for tests
   // that want deterministic raw bytes.
   gzipDict?: boolean;
+  // StarDict spec field controlling the body format. 'm' = plain
+  // UTF-8 text (default), 'h' = HTML, others are dict-specific.
+  // The reader picks rendering based on this field.
+  sametypesequence?: string;
 };
 
 export const writeStarDict = (
@@ -73,7 +77,7 @@ export const writeStarDict = (
     `wordcount=${sortedWords.length}\n` +
     `idxfilesize=${idx.length}\n` +
     'idxoffsetbits=32\n' +
-    'sametypesequence=m\n';
+    `sametypesequence=${options.sametypesequence ?? 'm'}\n`;
   const ifo = encodeUtf8(ifoText);
   return {ifo, idx, dict};
 };

--- a/src/core/dict/stardictLookup.ts
+++ b/src/core/dict/stardictLookup.ts
@@ -6,7 +6,7 @@
 // base dict (sync bytes wrapped in async) and runtime-discovered user
 // dicts (three files fetched from external storage).
 
-import type {DictEntry, DictSource} from '../lookup';
+import type {DefinitionFormat, DictEntry, DictSource} from '../lookup';
 import {createLazyAsyncSource} from './lazyAsyncSource';
 import {buildDict, lookupDict, type ParsedDict} from './stardict/stardictDict';
 
@@ -25,15 +25,23 @@ export type LoadDictBytes = () => Promise<DictBytes | null>;
 export type StardictLookupDeps = {
   name: string;
   loadBase: LoadDictBytes;
+  // Explicit format override. Used by the bundled WordNet base dict
+  // (passes 'wordnet') so the popup parses senses. If omitted, the
+  // format is auto-derived from the .ifo's sametypesequence.
+  format?: DefinitionFormat;
   logger?: {warn: (msg: string) => void};
 };
 
-const lookupParsed = (
-  parsed: ParsedDict,
-  word: string,
-): DictEntry | null => {
-  const hit = lookupDict(parsed, word);
-  return hit ? {word: hit.canonicalWord, definition: hit.definition} : null;
+// StarDict spec: `sametypesequence=m` is plain UTF-8 text, `=h` is
+// HTML, and several others (`x`, `y`, `n`, …) are dict-specific
+// formats we don't currently render. Anything other than `h` falls
+// back to plain text — the strings still display, just without
+// structure.
+const formatFromMeta = (meta: ParsedDict['meta']): DefinitionFormat => {
+  if (meta.sametypesequence === 'h') {
+    return 'html';
+  }
+  return 'plain';
 };
 
 export const createStardictLookup = (
@@ -46,6 +54,13 @@ export const createStardictLookup = (
     logTag: `stardict:${deps.name}`,
     load: deps.loadBase,
     parse: bytes => buildDict(bytes.ifo, bytes.idx, bytes.dict, bytes.syn),
-    lookup: lookupParsed,
+    lookup: (parsed, word): DictEntry | null => {
+      const hit = lookupDict(parsed, word);
+      if (!hit) {
+        return null;
+      }
+      const format = deps.format ?? formatFromMeta(parsed.meta);
+      return {word: hit.canonicalWord, definition: hit.definition, format};
+    },
     logger: deps.logger,
   });

--- a/src/core/dict/stardictLookup.ts
+++ b/src/core/dict/stardictLookup.ts
@@ -7,6 +7,7 @@
 // dicts (three files fetched from external storage).
 
 import type {DictEntry, DictSource} from '../lookup';
+import {createLazyAsyncSource} from './lazyAsyncSource';
 import {buildDict, lookupDict, type ParsedDict} from './stardict/stardictDict';
 
 export type DictBytes = {
@@ -27,69 +28,24 @@ export type StardictLookupDeps = {
   logger?: {warn: (msg: string) => void};
 };
 
+const lookupParsed = (
+  parsed: ParsedDict,
+  word: string,
+): DictEntry | null => {
+  const hit = lookupDict(parsed, word);
+  return hit ? {word: hit.canonicalWord, definition: hit.definition} : null;
+};
+
 export const createStardictLookup = (
   deps: StardictLookupDeps,
-): DictSource => {
-  const warn = deps.logger?.warn ?? (() => {});
-  const tag = `stardict:${deps.name}`;
-  let dict: ParsedDict | null = null;
-  let absent = false;
-  let inFlight: Promise<void> | null = null;
-
-  const doLoad = async (): Promise<void> => {
-    let bytes: DictBytes | null;
-    try {
-      bytes = await deps.loadBase();
-    } catch (e) {
-      warn(`[${tag}] loader threw: ${(e as Error).message}`);
-      throw e;
-    }
-    if (bytes === null) {
-      // Intentional opt-out — stick so we don't burn loader calls.
-      absent = true;
-      return;
-    }
-    try {
-      dict = buildDict(bytes.ifo, bytes.idx, bytes.dict, bytes.syn);
-    } catch (e) {
-      warn(`[${tag}] buildDict threw: ${(e as Error).message}`);
-      throw e;
-    }
-  };
-
-  const ensureLoaded = async (): Promise<void> => {
-    if (dict !== null || absent) {
-      return;
-    }
-    // Memoise the in-flight promise so concurrent first lookups share
-    // one underlying load+parse pass. Clear on settle so a failed
-    // attempt can be retried by the NEXT lookup (not by the racing
-    // concurrent ones — they all observe the same failure here).
-    if (inFlight === null) {
-      inFlight = doLoad().finally(() => {
-        inFlight = null;
-      });
-    }
-    try {
-      await inFlight;
-    } catch {
-      // observe via dict===null below
-    }
-  };
-
-  return {
+): DictSource =>
+  createLazyAsyncSource<DictBytes, ParsedDict>({
     name: deps.name,
-    async lookup(word: string): Promise<DictEntry | null> {
-      const trimmed = word.trim();
-      if (!trimmed) {
-        return null;
-      }
-      await ensureLoaded();
-      if (dict === null) {
-        return null;
-      }
-      const hit = lookupDict(dict, trimmed);
-      return hit ? {word: hit.canonicalWord, definition: hit.definition} : null;
-    },
-  };
-};
+    // Preserve the long-standing "[stardict:<name>] ..." log prefix
+    // so existing on-device logcat searches and tests keep working.
+    logTag: `stardict:${deps.name}`,
+    load: deps.loadBase,
+    parse: bytes => buildDict(bytes.ifo, bytes.idx, bytes.dict, bytes.syn),
+    lookup: lookupParsed,
+    logger: deps.logger,
+  });

--- a/src/core/lookup.ts
+++ b/src/core/lookup.ts
@@ -7,9 +7,25 @@
 //   of hits. The popup renders one section per hit when there are
 //   ≥2; a single hit renders inline as before.
 
+// How a definition's body should be rendered.
+//
+//   'wordnet' — looks like a Princeton WordNet entry. The popup
+//               parses senses + POS + examples + synonyms and renders
+//               them as discrete blocks.
+//   'html'    — body contains HTML markup (StarDicts with
+//               sametypesequence=h, or any source that knowingly
+//               emits HTML). The popup strips tags + decodes
+//               entities and renders as plain text.
+//   'plain'   — neither of the above. Render the string verbatim.
+//
+// Sources set this at lookup time based on what they know about
+// their content, instead of the popup guessing per render.
+export type DefinitionFormat = 'wordnet' | 'html' | 'plain';
+
 export type DictEntry = {
   word: string;
   definition: string;
+  format: DefinitionFormat;
 };
 
 // One source's contribution to the result. `source` is the name of

--- a/src/sdk/utf8.ts
+++ b/src/sdk/utf8.ts
@@ -108,6 +108,13 @@ export const decodeUtf8 = (bytes: Uint8Array): string => {
   return manualDecodeUtf8(bytes);
 };
 
+// Strip a leading UTF-8 byte-order mark if present. The sequence is
+// EF BB BF in raw bytes, which decodes to U+FEFF as the first
+// character of the resulting string. Many text-editor saves and
+// some sync tools insert a BOM that callers don't want to see.
+export const stripBom = (s: string): string =>
+  s.charCodeAt(0) === 0xfeff ? s.slice(1) : s;
+
 // Test-only escape hatch so we can exercise the manual path even when
 // TextEncoder/TextDecoder ARE available in the host.
 export const __testing__ = {manualEncodeUtf8, manualDecodeUtf8};

--- a/src/ui/DefinitionPopup.tsx
+++ b/src/ui/DefinitionPopup.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
-import {Pressable, ScrollView, StyleSheet, Text, View} from 'react-native';
+import {Pressable, ScrollView, Text, View} from 'react-native';
 import {PluginManager} from 'sn-plugin-lib';
 import {
   getCurrentState,
@@ -7,12 +7,9 @@ import {
   subscribe,
   type PopupState,
 } from './popupController';
-import {
-  labelForPos,
-  parseWordNetEntry,
-  type WordNetSense,
-} from './wordnetFormatter';
-import {htmlToPlainText} from './htmlToPlainText';
+import {parseWordNetEntry} from './wordnetFormatter';
+import {SourceSection} from './SourceSection';
+import {popupStyles as styles} from './popupStyles';
 import {t} from '../i18n/i18n';
 import type {SourceHit} from '../core/lookup';
 
@@ -42,8 +39,8 @@ export default function DefinitionPopup(): React.JSX.Element {
 
   // Parse each hit's WordNet entry once per definition change. Memoise
   // so subsequent re-renders (e.g. from popupController state echoes)
-  // don't re-tokenise. CSV/JSON/MDX dicts in Step 3 will go through
-  // the same parser; non-WordNet shapes fall back to raw text below.
+  // don't re-tokenise. Non-WordNet shapes fall back to the
+  // HTML-strip / plain-text path inside SourceSection.
   const parsedHits = useMemo<ParsedHit[]>(() => {
     if (!state.visible || state.result.hits.length === 0) {
       return [];
@@ -99,208 +96,3 @@ export default function DefinitionPopup(): React.JSX.Element {
     </View>
   );
 }
-
-type SourceSectionProps = {
-  hit: SourceHit;
-  parsed: ReturnType<typeof parseWordNetEntry>;
-  showBadge: boolean;
-  showDivider: boolean;
-};
-
-const SourceSection = ({
-  hit,
-  parsed,
-  showBadge,
-  showDivider,
-}: SourceSectionProps): React.JSX.Element => (
-  <View style={[styles.section, showDivider && styles.sectionDivider]}>
-    {showBadge ? (
-      <View style={styles.sectionHeader}>
-        <Text style={styles.sourceBadge}>{hit.source}</Text>
-      </View>
-    ) : null}
-    {parsed && !parsed.parseFailed ? (
-      <SenseList senses={parsed.senses} />
-    ) : (
-      // Fallback for non-WordNet content. Run through the HTML
-      // stripper so dicts with sametypesequence=h (Wiktionary-derived
-      // StarDicts and similar) render as readable plain text instead
-      // of leaking <i>/<br>/<ol>/<li> tags into the popup. No-op for
-      // genuinely plain text (no `<` or `&`).
-      <Text style={styles.definition}>
-        {htmlToPlainText(hit.entry.definition)}
-      </Text>
-    )}
-  </View>
-);
-
-type SenseListProps = {senses: WordNetSense[]};
-
-const SenseList = ({senses}: SenseListProps): React.JSX.Element => (
-  <View>
-    {senses.map((sense, i) => (
-      <SenseBlock
-        key={`${sense.pos ?? '?'}-${sense.index}-${i}`}
-        sense={sense}
-        showDivider={i > 0}
-      />
-    ))}
-  </View>
-);
-
-type SenseBlockProps = {sense: WordNetSense; showDivider: boolean};
-
-const SenseBlock = ({sense, showDivider}: SenseBlockProps): React.JSX.Element => (
-  <View style={[styles.sense, showDivider && styles.senseDivider]}>
-    <View style={styles.senseHeader}>
-      {sense.pos ? (
-        <Text style={styles.posBadge}>{labelForPos(sense.pos)}</Text>
-      ) : null}
-      <Text style={styles.senseIndex}>{`${sense.index}.`}</Text>
-    </View>
-    <Text style={styles.definition}>{sense.definition}</Text>
-    {sense.examples.length > 0 ? (
-      <View style={styles.examples}>
-        {sense.examples.map((ex, j) => (
-          <Text key={j} style={styles.example}>
-            “{ex}”
-          </Text>
-        ))}
-      </View>
-    ) : null}
-    {sense.synonyms.length > 0 ? (
-      <Text style={styles.synonyms}>
-        <Text style={styles.synonymsLabel}>{`${t('popup.synonyms')}: `}</Text>
-        {sense.synonyms.join(', ')}
-      </Text>
-    ) : null}
-  </View>
-);
-
-const styles = StyleSheet.create({
-  hidden: {width: 0, height: 0},
-  backdrop: {
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: 24,
-  },
-  card: {
-    minWidth: 480,
-    maxWidth: 640,
-    maxHeight: 520,
-    backgroundColor: '#ffffff',
-    borderRadius: 8,
-    borderWidth: 1,
-    borderColor: '#000000',
-    padding: 20,
-  },
-  word: {
-    fontSize: 28,
-    fontWeight: '700',
-    color: '#000000',
-  },
-  ocrLabel: {
-    marginTop: 4,
-    fontSize: 14,
-    color: '#555555',
-  },
-  body: {
-    marginTop: 12,
-    marginBottom: 16,
-  },
-  section: {
-    paddingTop: 4,
-  },
-  sectionDivider: {
-    marginTop: 14,
-    paddingTop: 14,
-    borderTopWidth: 1,
-    borderTopColor: '#bbbbbb',
-  },
-  sectionHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 8,
-  },
-  sourceBadge: {
-    fontSize: 14,
-    fontWeight: '700',
-    color: '#000000',
-    paddingHorizontal: 8,
-    paddingVertical: 3,
-    borderWidth: 1,
-    borderColor: '#000000',
-    borderRadius: 3,
-  },
-  definition: {
-    fontSize: 17,
-    lineHeight: 24,
-    color: '#000000',
-  },
-  notFound: {
-    fontSize: 18,
-    color: '#555555',
-    fontStyle: 'italic',
-  },
-  sense: {
-    paddingVertical: 10,
-  },
-  senseDivider: {
-    borderTopWidth: 1,
-    borderTopColor: '#dddddd',
-  },
-  senseHeader: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 6,
-  },
-  posBadge: {
-    fontSize: 12,
-    fontStyle: 'italic',
-    color: '#555555',
-    marginRight: 8,
-    paddingHorizontal: 6,
-    paddingVertical: 1,
-    borderWidth: 1,
-    borderColor: '#888888',
-    borderRadius: 3,
-  },
-  senseIndex: {
-    fontSize: 16,
-    fontWeight: '600',
-    color: '#000000',
-  },
-  examples: {
-    marginTop: 6,
-    marginLeft: 12,
-  },
-  example: {
-    fontSize: 15,
-    fontStyle: 'italic',
-    color: '#444444',
-    lineHeight: 22,
-  },
-  synonyms: {
-    marginTop: 8,
-    fontSize: 14,
-    color: '#444444',
-    lineHeight: 20,
-  },
-  synonymsLabel: {
-    fontWeight: '600',
-    color: '#000000',
-  },
-  closeButton: {
-    alignSelf: 'flex-end',
-    paddingVertical: 8,
-    paddingHorizontal: 20,
-    borderWidth: 1,
-    borderColor: '#000000',
-    borderRadius: 4,
-  },
-  closeLabel: {
-    fontSize: 16,
-    color: '#000000',
-  },
-});

--- a/src/ui/DefinitionPopup.tsx
+++ b/src/ui/DefinitionPopup.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {Pressable, ScrollView, Text, View} from 'react-native';
 import {PluginManager} from 'sn-plugin-lib';
 import {
@@ -7,16 +7,9 @@ import {
   subscribe,
   type PopupState,
 } from './popupController';
-import {parseWordNetEntry} from './wordnetFormatter';
 import {SourceSection} from './SourceSection';
 import {popupStyles as styles} from './popupStyles';
 import {t} from '../i18n/i18n';
-import type {SourceHit} from '../core/lookup';
-
-type ParsedHit = {
-  hit: SourceHit;
-  parsed: ReturnType<typeof parseWordNetEntry>;
-};
 
 export default function DefinitionPopup(): React.JSX.Element {
   const [state, setState] = useState<PopupState>(getCurrentState);
@@ -36,20 +29,6 @@ export default function DefinitionPopup(): React.JSX.Element {
       /* ignore — overlay is going away regardless */
     });
   }, []);
-
-  // Parse each hit's WordNet entry once per definition change. Memoise
-  // so subsequent re-renders (e.g. from popupController state echoes)
-  // don't re-tokenise. Non-WordNet shapes fall back to the
-  // HTML-strip / plain-text path inside SourceSection.
-  const parsedHits = useMemo<ParsedHit[]>(() => {
-    if (!state.visible || state.result.hits.length === 0) {
-      return [];
-    }
-    return state.result.hits.map(hit => ({
-      hit,
-      parsed: parseWordNetEntry(hit.entry.definition),
-    }));
-  }, [state]);
 
   if (!state.visible) {
     // Zero-size, non-interactive when nothing to show — matches the
@@ -75,11 +54,10 @@ export default function DefinitionPopup(): React.JSX.Element {
               {`${t('popup.notFoundFor')} "${state.result.queriedFor}".`}
             </Text>
           ) : (
-            parsedHits.map((ph, i) => (
+            hits.map((hit, i) => (
               <SourceSection
-                key={`${ph.hit.source}-${i}`}
-                hit={ph.hit}
-                parsed={ph.parsed}
+                key={`${hit.source}-${i}`}
+                hit={hit}
                 showBadge={showSourceBadges}
                 showDivider={i > 0}
               />

--- a/src/ui/SourceSection.tsx
+++ b/src/ui/SourceSection.tsx
@@ -29,10 +29,14 @@ export const SourceSection = ({
   showBadge,
   showDivider,
 }: SourceSectionProps): React.JSX.Element => {
-  // Memoise the format-specific transformation. Re-runs only when
-  // the entry's content changes, not on every popup re-render.
+  // Memoise the format-specific transformation. Key on the primitive
+  // fields rather than the entry object so a parent re-creating
+  // {word, definition, format} with the same values doesn't churn
+  // the WordNet parser. Today's call paths produce a fresh entry
+  // only when a new lookup completes, but keying on primitives makes
+  // that property explicit and footgun-free for future call sites.
+  const {definition, format} = hit.entry;
   const body = useMemo(() => {
-    const {definition, format} = hit.entry;
     if (format === 'wordnet') {
       const parsed = parseWordNetEntry(definition);
       if (parsed && !parsed.parseFailed) {
@@ -47,7 +51,7 @@ export const SourceSection = ({
     }
     // 'plain'
     return <Text style={styles.definition}>{definition}</Text>;
-  }, [hit.entry]);
+  }, [definition, format]);
 
   return (
     <View style={[styles.section, showDivider && styles.sectionDivider]}>

--- a/src/ui/SourceSection.tsx
+++ b/src/ui/SourceSection.tsx
@@ -1,49 +1,62 @@
 // Per-hit popup section. Renders the bordered source badge (only
 // when the parent decides ≥2 hits warrant disambiguation) followed
-// by either the parsed-WordNet view or the HTML-stripped fallback.
+// by the format-appropriate body renderer.
 //
-// Decision of which renderer to use today is heuristic — based on
-// whether parseWordNetEntry succeeded. Issue #6 will move this to an
-// explicit format hint on the hit.
+// The render mode is now driven by `hit.entry.format` set explicitly
+// by the source factory at lookup time — no per-render heuristic
+// detection. Three modes:
+//
+//   'wordnet' — parse with parseWordNetEntry + render SenseList
+//   'html'    — strip tags via htmlToPlainText and render as text
+//   'plain'   — render the definition string verbatim
 
-import React from 'react';
+import React, {useMemo} from 'react';
 import {Text, View} from 'react-native';
 import type {SourceHit} from '../core/lookup';
-import type {parseWordNetEntry} from './wordnetFormatter';
+import {parseWordNetEntry} from './wordnetFormatter';
 import {SenseList} from './senseBlocks';
 import {htmlToPlainText} from './htmlToPlainText';
 import {popupStyles as styles} from './popupStyles';
 
 type SourceSectionProps = {
   hit: SourceHit;
-  parsed: ReturnType<typeof parseWordNetEntry>;
   showBadge: boolean;
   showDivider: boolean;
 };
 
 export const SourceSection = ({
   hit,
-  parsed,
   showBadge,
   showDivider,
-}: SourceSectionProps): React.JSX.Element => (
-  <View style={[styles.section, showDivider && styles.sectionDivider]}>
-    {showBadge ? (
-      <View style={styles.sectionHeader}>
-        <Text style={styles.sourceBadge}>{hit.source}</Text>
-      </View>
-    ) : null}
-    {parsed && !parsed.parseFailed ? (
-      <SenseList senses={parsed.senses} />
-    ) : (
-      // Fallback for non-WordNet content. Run through the HTML
-      // stripper so dicts with sametypesequence=h (Wiktionary-derived
-      // StarDicts and similar) render as readable plain text instead
-      // of leaking <i>/<br>/<ol>/<li> tags into the popup. No-op for
-      // genuinely plain text (no `<` or `&`).
-      <Text style={styles.definition}>
-        {htmlToPlainText(hit.entry.definition)}
-      </Text>
-    )}
-  </View>
-);
+}: SourceSectionProps): React.JSX.Element => {
+  // Memoise the format-specific transformation. Re-runs only when
+  // the entry's content changes, not on every popup re-render.
+  const body = useMemo(() => {
+    const {definition, format} = hit.entry;
+    if (format === 'wordnet') {
+      const parsed = parseWordNetEntry(definition);
+      if (parsed && !parsed.parseFailed) {
+        return <SenseList senses={parsed.senses} />;
+      }
+      // The source declared WordNet but the body didn't parse as one.
+      // Fall back to plain rendering rather than dropping content.
+      return <Text style={styles.definition}>{definition}</Text>;
+    }
+    if (format === 'html') {
+      return <Text style={styles.definition}>{htmlToPlainText(definition)}</Text>;
+    }
+    // 'plain'
+    return <Text style={styles.definition}>{definition}</Text>;
+  }, [hit.entry]);
+
+  return (
+    <View style={[styles.section, showDivider && styles.sectionDivider]}>
+      {showBadge ? (
+        <View style={styles.sectionHeader}>
+          <Text style={styles.sourceBadge}>{hit.source}</Text>
+        </View>
+      ) : null}
+      {body}
+    </View>
+  );
+};

--- a/src/ui/SourceSection.tsx
+++ b/src/ui/SourceSection.tsx
@@ -1,0 +1,49 @@
+// Per-hit popup section. Renders the bordered source badge (only
+// when the parent decides ≥2 hits warrant disambiguation) followed
+// by either the parsed-WordNet view or the HTML-stripped fallback.
+//
+// Decision of which renderer to use today is heuristic — based on
+// whether parseWordNetEntry succeeded. Issue #6 will move this to an
+// explicit format hint on the hit.
+
+import React from 'react';
+import {Text, View} from 'react-native';
+import type {SourceHit} from '../core/lookup';
+import type {parseWordNetEntry} from './wordnetFormatter';
+import {SenseList} from './senseBlocks';
+import {htmlToPlainText} from './htmlToPlainText';
+import {popupStyles as styles} from './popupStyles';
+
+type SourceSectionProps = {
+  hit: SourceHit;
+  parsed: ReturnType<typeof parseWordNetEntry>;
+  showBadge: boolean;
+  showDivider: boolean;
+};
+
+export const SourceSection = ({
+  hit,
+  parsed,
+  showBadge,
+  showDivider,
+}: SourceSectionProps): React.JSX.Element => (
+  <View style={[styles.section, showDivider && styles.sectionDivider]}>
+    {showBadge ? (
+      <View style={styles.sectionHeader}>
+        <Text style={styles.sourceBadge}>{hit.source}</Text>
+      </View>
+    ) : null}
+    {parsed && !parsed.parseFailed ? (
+      <SenseList senses={parsed.senses} />
+    ) : (
+      // Fallback for non-WordNet content. Run through the HTML
+      // stripper so dicts with sametypesequence=h (Wiktionary-derived
+      // StarDicts and similar) render as readable plain text instead
+      // of leaking <i>/<br>/<ol>/<li> tags into the popup. No-op for
+      // genuinely plain text (no `<` or `&`).
+      <Text style={styles.definition}>
+        {htmlToPlainText(hit.entry.definition)}
+      </Text>
+    )}
+  </View>
+);

--- a/src/ui/popupStyles.ts
+++ b/src/ui/popupStyles.ts
@@ -1,0 +1,134 @@
+// Shared StyleSheet for the popup and its sub-components. Kept in one
+// place so tweaks to the visual language (font sizes, badge borders,
+// dividers) don't require touching three files. e-ink-friendly: black
+// text + bordered surfaces, no backgrounds beyond white.
+
+import {StyleSheet} from 'react-native';
+
+export const popupStyles = StyleSheet.create({
+  hidden: {width: 0, height: 0},
+  backdrop: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 24,
+  },
+  card: {
+    minWidth: 480,
+    maxWidth: 640,
+    maxHeight: 520,
+    backgroundColor: '#ffffff',
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#000000',
+    padding: 20,
+  },
+  word: {
+    fontSize: 28,
+    fontWeight: '700',
+    color: '#000000',
+  },
+  ocrLabel: {
+    marginTop: 4,
+    fontSize: 14,
+    color: '#555555',
+  },
+  body: {
+    marginTop: 12,
+    marginBottom: 16,
+  },
+  section: {
+    paddingTop: 4,
+  },
+  sectionDivider: {
+    marginTop: 14,
+    paddingTop: 14,
+    borderTopWidth: 1,
+    borderTopColor: '#bbbbbb',
+  },
+  sectionHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  sourceBadge: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#000000',
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderWidth: 1,
+    borderColor: '#000000',
+    borderRadius: 3,
+  },
+  definition: {
+    fontSize: 17,
+    lineHeight: 24,
+    color: '#000000',
+  },
+  notFound: {
+    fontSize: 18,
+    color: '#555555',
+    fontStyle: 'italic',
+  },
+  sense: {
+    paddingVertical: 10,
+  },
+  senseDivider: {
+    borderTopWidth: 1,
+    borderTopColor: '#dddddd',
+  },
+  senseHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 6,
+  },
+  posBadge: {
+    fontSize: 12,
+    fontStyle: 'italic',
+    color: '#555555',
+    marginRight: 8,
+    paddingHorizontal: 6,
+    paddingVertical: 1,
+    borderWidth: 1,
+    borderColor: '#888888',
+    borderRadius: 3,
+  },
+  senseIndex: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#000000',
+  },
+  examples: {
+    marginTop: 6,
+    marginLeft: 12,
+  },
+  example: {
+    fontSize: 15,
+    fontStyle: 'italic',
+    color: '#444444',
+    lineHeight: 22,
+  },
+  synonyms: {
+    marginTop: 8,
+    fontSize: 14,
+    color: '#444444',
+    lineHeight: 20,
+  },
+  synonymsLabel: {
+    fontWeight: '600',
+    color: '#000000',
+  },
+  closeButton: {
+    alignSelf: 'flex-end',
+    paddingVertical: 8,
+    paddingHorizontal: 20,
+    borderWidth: 1,
+    borderColor: '#000000',
+    borderRadius: 4,
+  },
+  closeLabel: {
+    fontSize: 16,
+    color: '#000000',
+  },
+});

--- a/src/ui/senseBlocks.tsx
+++ b/src/ui/senseBlocks.tsx
@@ -1,0 +1,55 @@
+// Renderer for parsed WordNet senses. Two components, both pure /
+// presentational — no state, no controllers, no SDK access. Mounted
+// from SourceSection's WordNet branch.
+
+import React from 'react';
+import {Text, View} from 'react-native';
+import {labelForPos, type WordNetSense} from './wordnetFormatter';
+import {popupStyles as styles} from './popupStyles';
+import {t} from '../i18n/i18n';
+
+type SenseListProps = {senses: WordNetSense[]};
+
+export const SenseList = ({senses}: SenseListProps): React.JSX.Element => (
+  <View>
+    {senses.map((sense, i) => (
+      <SenseBlock
+        key={`${sense.pos ?? '?'}-${sense.index}-${i}`}
+        sense={sense}
+        showDivider={i > 0}
+      />
+    ))}
+  </View>
+);
+
+type SenseBlockProps = {sense: WordNetSense; showDivider: boolean};
+
+export const SenseBlock = ({
+  sense,
+  showDivider,
+}: SenseBlockProps): React.JSX.Element => (
+  <View style={[styles.sense, showDivider && styles.senseDivider]}>
+    <View style={styles.senseHeader}>
+      {sense.pos ? (
+        <Text style={styles.posBadge}>{labelForPos(sense.pos)}</Text>
+      ) : null}
+      <Text style={styles.senseIndex}>{`${sense.index}.`}</Text>
+    </View>
+    <Text style={styles.definition}>{sense.definition}</Text>
+    {sense.examples.length > 0 ? (
+      <View style={styles.examples}>
+        {sense.examples.map((ex, j) => (
+          <Text key={j} style={styles.example}>
+            “{ex}”
+          </Text>
+        ))}
+      </View>
+    ) : null}
+    {sense.synonyms.length > 0 ? (
+      <Text style={styles.synonyms}>
+        <Text style={styles.synonymsLabel}>{`${t('popup.synonyms')}: `}</Text>
+        {sense.synonyms.join(', ')}
+      </Text>
+    ) : null}
+  </View>
+);


### PR DESCRIPTION
## Summary

Four architectural improvements identified in the code-quality review thread, each landed as its own commit. No user-visible behaviour change. The release plumbing (\`package.json\` / \`PluginConfig.json\` versions) is untouched.

| Commit | Issue | What it does |
|---|---|---|
| \`dd793a3\` | [#8](https://github.com/j-raghavan/sn-dictionary/issues/8) | Extract \`SourceSection\` / \`SenseList\` / \`SenseBlock\` / styles from \`DefinitionPopup.tsx\` |
| \`e0506f3\` | [#1](https://github.com/j-raghavan/sn-dictionary/issues/1) (was #5) | Unify lazy-load harness — one helper for StarDict / CSV / JSON |
| \`59d6d34\` | [#6](https://github.com/j-raghavan/sn-dictionary/issues/6) | Explicit \`DefinitionFormat\` on every \`DictEntry\`; popup switches on it |
| \`e4c439e\` | [#7](https://github.com/j-raghavan/sn-dictionary/issues/7) | End-to-end integration test (6 cases) over an in-memory VFS |

## Why these four together

They build on each other in dependency order:

1. **#8 (popup split)** — pure mechanical refactor, lands first to give #6 a clean place to put the format switch.
2. **#1 (lazy-loader unification)** — generalises \`createLazyAsyncSource\` to \`<TLoaded, TParsed>\`. \`createStardictLookup\` becomes a 15-line factory delegating to the unified helper. Size caps move into per-format \`parse\` steps. The harness is now format-agnostic; adding the next format (when MDX comes back) is one new factory file, not another copy of the load-and-retry machinery.
3. **#6 (explicit format)** — adds \`format: 'wordnet' | 'html' | 'plain'\` to \`DictEntry\`, set by the source factory at lookup time. The popup stops guessing per-render and just switches on the field. Each render mode has a single explicit owner.
4. **#7 (integration test)** — wires the real production modules together against an in-memory VFS. Six cases including regressions for the two compositional bugs we'd already shipped (\`.syn\` ignored, in-flight mutation race).

Order matters: #1 makes #6 cleaner to write, and #6 makes #7's assertions cleaner to assert on.

## Architectural delta

### Before this PR

- Two parallel lazy-load implementations (one in \`createStardictLookup\`, one in \`createLazyAsyncSource\`), each with their own \`ensureLoaded\` / \`inFlight\` machinery.
- The popup picked its render mode (WordNet / HTML / plain) by trial-parsing the definition string on every render — content detection baked into the view layer.
- \`DefinitionPopup.tsx\` was ~250 LOC defining 4 React components + 100 LOC of inline styles.
- 100% of test coverage was per-layer unit tests. Two compositional bugs had already shipped because no test wired the layers together.

### After this PR

- One generic \`createLazyAsyncSource<TLoaded, TParsed>\` harness. \`TLoaded\` is whatever the parser needs — \`DictBytes\` (the multi-buffer struct) for StarDict, \`Uint8Array\` for CSV / JSON. Both formats share one set of load+retry semantics.
- \`DictEntry.format\` is set by the source factory; \`SourceSection\` switches on it explicitly. Heuristic-based render-mode picking is gone. A future content type adds one enum case + one switch arm.
- Popup logic split across \`DefinitionPopup.tsx\` (~70 LOC), \`SourceSection.tsx\` (~55 LOC), \`senseBlocks.tsx\` (~55 LOC), \`popupStyles.ts\` (~115 LOC).
- Unit tests for each layer + an end-to-end test covering the layer joins. The integration test catches the regression class that the units missed.

## Coverage and tests

- **323 / 323** tests pass (was 287 at start of this PR; +36 across the four commits).
- Coverage **99.33% statements / 97.16% branches** — comfortably above the 97% bar from \`CLAUDE.md\`.
- \`stardictLookup.ts\`, \`SourceSection.tsx\`, \`lazyAsyncSource.ts\` all at 100% / 100% themselves.
- New test files:
  - \`__tests__/end-to-end.test.tsx\` — 6 cases.
  - \`__tests__/_helpers/inMemoryVfs.ts\` — extracted shared VFS helper.

## What this PR is NOT

- **No version bump.** CI handles release versioning; \`package.json\` and \`PluginConfig.json\` are untouched.
- **No new functionality** for end users. A v1.0.3 build with this PR merged behaves identically to v1.0.3 today — same lookup pipeline, same popup, same dict support, same caps.
- **No new runtime dependencies.** All changes are pure JS / TS internal.
- **No on-device behaviour change.** Verified locally; the popup screenshots from the on-device tests in PR #4 would render byte-identically with this PR applied.
- **MDX is still deferred.** Unaffected by this PR; the unified harness *enables* a clean MDX addition later, but doesn't introduce one.

## Test plan

- [x] \`npm run lint\` clean
- [x] \`npx jest\` — 323 / 323 pass
- [x] \`npx jest --coverage\` — ≥97% branches
- [x] Each commit is independently green (verified during the per-commit \`npm run lint && npx jest\` cycle)
- [x] No public-API surface change visible to \`index.js\` beyond the explicit \`format: 'wordnet'\` argument now passed to the bundled \`createStardictLookup\` (additive, has a default)

## Follow-ups not in this PR

- The diacritic-strip enhancement we discussed for non-Latin Wiktionary dicts (would unlock \`namaskar\` → \`namaskār\` style matches). Untouched by this PR; remains a candidate for v1.0.4.
- MDX support. Still licence-blocked; the unified harness this PR introduces is the foundation if/when we revisit.