### PR TITLE
feat(phonetics): optional pronunciation field for CSV/JSON dicts

### DIFF
--- a/__tests__/DefinitionPopup.test.tsx
+++ b/__tests__/DefinitionPopup.test.tsx
@@ -90,6 +90,236 @@ describe('DefinitionPopup', () => {
     expect(collectText(renderPopup())).toBe('');
   });
 
+  test('when two hits disagree on phonetic, the header shows the first one (later still visible in its section)', () => {
+    // Documented rule: the header phonetic is the FIRST hit with a
+    // phonetic; later disagreements stay reachable per-source in
+    // each section body. Pinning the rule so a future refactor
+    // can't silently swap to "last wins" or "merge".
+    const tree = renderPopup();
+    act(() => {
+      showDefinition({
+        queriedFor: 'tomato',
+        hits: [
+          {
+            source: 'AmEng',
+            entry: {
+              word: 'tomato',
+              definition: 'red fruit (US)',
+              format: 'plain',
+              phonetic: 'tuh-MAY-toh',
+            },
+          },
+          {
+            source: 'BrEng',
+            entry: {
+              word: 'tomato',
+              definition: 'red fruit (UK)',
+              format: 'plain',
+              phonetic: 'tuh-MAH-toh',
+            },
+          },
+        ],
+        loading: [],
+      });
+    });
+    const text = collectText(tree);
+    // Both phonetics appear *somewhere* in the rendered tree (the
+    // first in the header, the second only via its section body if
+    // a future render path exposes it; today only the header path
+    // renders phonetics, so we assert the rule by header position).
+    expect(text).toContain('tuh-MAY-toh');
+    // Header label encodes the chosen phonetic — first hit wins.
+    const headerLabelled = tree.root.findAllByProps({
+      accessibilityLabel: 'Pronunciation: tuh-MAY-toh',
+    });
+    expect(headerLabelled.length).toBe(1);
+    // Negative pin: there is NO header label for the second hit's
+    // phonetic. (Equivalent to "last wins" / "merge" — explicitly
+    // not the rule.)
+    const wrongHeader = tree.root.findAllByProps({
+      accessibilityLabel: 'Pronunciation: tuh-MAH-toh',
+    });
+    expect(wrongHeader.length).toBe(0);
+  });
+
+  test('header phonetic comes from the first hit that supplies one (skips earlier hits without)', () => {
+    // Multi-dict scenario: WordNet has no phonetic, but the user's
+    // CSV does. The header should still surface the CSV's phonetic
+    // rather than nothing.
+    const tree = renderPopup();
+    act(() => {
+      showDefinition({
+        queriedFor: 'arrakis',
+        hits: [
+          {
+            source: 'WordNet',
+            entry: {
+              word: 'arrakis',
+              definition: 'no entry',
+              format: 'plain',
+            },
+          },
+          {
+            source: 'Dune',
+            entry: {
+              word: 'ARRAKIS',
+              definition: 'the planet known as Dune',
+              format: 'plain',
+              phonetic: 'uh-RAK-is',
+            },
+          },
+        ],
+        loading: [],
+      });
+    });
+    expect(collectText(tree)).toContain('uh-RAK-is');
+  });
+
+  test('phonetic font-size scales with the user-selected font size', () => {
+    const tree = renderPopup();
+    act(() => {
+      showDefinition({
+        queriedFor: 'arrakis',
+        hits: [
+          {
+            source: 'Dune',
+            entry: {
+              word: 'ARRAKIS',
+              definition: 'the planet',
+              format: 'plain',
+              phonetic: 'uh-RAK-is',
+            },
+          },
+        ],
+        loading: [],
+      });
+    });
+    const findPhoneticFontSize = (): number => {
+      const json = tree.toJSON();
+      let captured: number | null = null;
+      const visit = (node: unknown): void => {
+        if (Array.isArray(node)) {
+          node.forEach(visit);
+          return;
+        }
+        if (
+          node &&
+          typeof node === 'object' &&
+          'props' in node &&
+          'children' in node
+        ) {
+          const obj = node as {
+            props: {style?: unknown};
+            children: unknown;
+          };
+          const text = JSON.stringify(obj.children);
+          if (text.includes('uh-RAK-is')) {
+            const flatten = (s: unknown): {fontSize?: number} => {
+              if (Array.isArray(s)) {
+                return Object.assign({}, ...s.map(flatten));
+              }
+              if (s && typeof s === 'object') {
+                return s as {fontSize?: number};
+              }
+              return {};
+            };
+            const flat = flatten(obj.props.style);
+            if (typeof flat.fontSize === 'number') {
+              captured = flat.fontSize;
+            }
+          }
+          visit(obj.children);
+        }
+      };
+      visit(json);
+      if (captured === null) {
+        throw new Error('phonetic Text not found');
+      }
+      return captured;
+    };
+    const baseFontSize = findPhoneticFontSize();
+    act(() => {
+      tree.root
+        .findAllByProps({
+          accessibilityRole: 'button',
+          accessibilityLabel: 'Increase text size',
+        })[0]
+        .props.onPress();
+    });
+    expect(findPhoneticFontSize()).toBeGreaterThan(baseFontSize);
+  });
+
+  test('phonetic Text exposes a localised "Pronunciation: ..." accessibilityLabel', () => {
+    const tree = renderPopup();
+    act(() => {
+      showDefinition({
+        queriedFor: 'arrakis',
+        hits: [
+          {
+            source: 'Dune',
+            entry: {
+              word: 'ARRAKIS',
+              definition: 'the planet',
+              format: 'plain',
+              phonetic: 'uh-RAK-is',
+            },
+          },
+        ],
+        loading: [],
+      });
+    });
+    // Match by the accessibility-label prefix; full string includes
+    // the phonetic value verbatim.
+    const labelled = tree.root.findAllByProps({
+      accessibilityLabel: 'Pronunciation: uh-RAK-is',
+    });
+    expect(labelled.length).toBe(1);
+  });
+
+  test('renders phonetic line under the headword when the first hit carries one', () => {
+    const tree = renderPopup();
+    act(() => {
+      showDefinition({
+        queriedFor: 'arrakis',
+        hits: [
+          {
+            source: 'Dune',
+            entry: {
+              word: 'ARRAKIS',
+              definition: 'the planet known as Dune',
+              format: 'plain',
+              phonetic: 'uh-RAK-is',
+            },
+          },
+        ],
+        loading: [],
+      });
+    });
+    const text = collectText(tree);
+    expect(text).toContain('ARRAKIS');
+    expect(text).toContain('uh-RAK-is');
+    // Phonetic precedes the definition body.
+    expect(text.indexOf('uh-RAK-is')).toBeLessThan(
+      text.indexOf('the planet known as Dune'),
+    );
+  });
+
+  test('omits the phonetic line entirely when the first hit has none', () => {
+    const tree = renderPopup();
+    act(() => {
+      showDefinition(found('WordNet', 'hello', 'a greeting'));
+    });
+    // No stray phonetic styling appears in the tree — sanity check by
+    // confirming the only text nodes between headword and definition
+    // are chrome, not a phonetic respelling. If a future regression
+    // adds an empty phonetic Text, it'd render an empty string but
+    // produce a Text node — collectText would show extra ' | '
+    // separators around 'hello'. Guard against the bug at the source:
+    // the phonetic style line must not appear in the JSON tree.
+    const json = JSON.stringify(tree.toJSON());
+    expect(json).not.toMatch(/"fontStyle":"italic"/);
+  });
+
   test('renders headword and definition for a single-source hit', () => {
     const tree = renderPopup();
     act(() => {

--- a/__tests__/csvDictSource.test.ts
+++ b/__tests__/csvDictSource.test.ts
@@ -238,6 +238,55 @@ describe('createCsvDictSource', () => {
     expect((await src.lookup('k'))?.definition).toBe('v');
   });
 
+  test('phoneticCol: surfaces a third column as DictEntry.phonetic', async () => {
+    const src = createCsvDictSource({
+      name: 'test',
+      loadBytes: async () =>
+        enc('ARRAKIS,the planet known as Dune,uh-RAK-is\n'),
+      phoneticCol: 2,
+    });
+    expect(await src.lookup('arrakis')).toEqual({
+      word: 'ARRAKIS',
+      definition: 'the planet known as Dune',
+      format: 'plain',
+      phonetic: 'uh-RAK-is',
+    });
+  });
+
+  test('phoneticCol: omitted in entries with empty phonetic field', async () => {
+    const src = createCsvDictSource({
+      name: 'test',
+      loadBytes: async () => enc('apple,fruit,\nbanana,yellow,buh-NAN-uh\n'),
+      phoneticCol: 2,
+    });
+    const apple = await src.lookup('apple');
+    // Empty third column means no phonetic — field is omitted, not ''.
+    expect(apple).toEqual({word: 'apple', definition: 'fruit', format: 'plain'});
+    expect(apple).not.toHaveProperty('phonetic');
+    const banana = await src.lookup('banana');
+    expect(banana?.phonetic).toBe('buh-NAN-uh');
+  });
+
+  test('phoneticCol: out-of-range column is treated as no phonetic, not a crash', async () => {
+    const src = createCsvDictSource({
+      name: 'test',
+      loadBytes: async () => enc('apple,fruit\n'),
+      phoneticCol: 9, // row only has 2 cells
+    });
+    const hit = await src.lookup('apple');
+    expect(hit).toEqual({word: 'apple', definition: 'fruit', format: 'plain'});
+    expect(hit).not.toHaveProperty('phonetic');
+  });
+
+  test('phoneticCol omitted: no phonetic surfaces even if extra cols exist', async () => {
+    // Backwards-compatibility: a CSV that happens to have a third
+    // column shouldn't accidentally leak it as phonetic when the
+    // caller never asked for one.
+    const src = fromCsv('ARRAKIS,the planet,uh-RAK-is\n');
+    const hit = await src.lookup('arrakis');
+    expect(hit).not.toHaveProperty('phonetic');
+  });
+
   test('lazy: loader fires once across many lookups', async () => {
     const loadBytes = jest.fn(async () => enc('apple,fruit\n'));
     const src = createCsvDictSource({name: 'test', loadBytes});

--- a/__tests__/i18n.test.ts
+++ b/__tests__/i18n.test.ts
@@ -57,6 +57,16 @@ describe('t (popup string lookup)', () => {
       }
     }
   });
+
+  test('every locale defines a non-empty popup.pronunciation', () => {
+    // Catches a missing translation when a future locale is added —
+    // the a11y label would silently fall back to en otherwise.
+    for (const locale of Object.keys(STRINGS)) {
+      const value = t('popup.pronunciation', locale);
+      expect(typeof value).toBe('string');
+      expect(value.length).toBeGreaterThan(0);
+    }
+  });
 });
 
 describe('detectLocale', () => {

--- a/__tests__/jsonDictSource.test.ts
+++ b/__tests__/jsonDictSource.test.ts
@@ -168,6 +168,58 @@ describe('createJsonDictSource', () => {
     expect((await src.lookup('apple'))?.definition).toBe('a fruit, it’s red');
   });
 
+  test('array shape: surfaces phonetic field on the entry', async () => {
+    const src = fromJson(
+      JSON.stringify([
+        {word: 'arrakis', definition: 'the planet', phonetic: 'uh-RAK-is'},
+      ]),
+    );
+    expect(await src.lookup('arrakis')).toEqual({
+      word: 'arrakis',
+      definition: 'the planet',
+      format: 'plain',
+      phonetic: 'uh-RAK-is',
+    });
+  });
+
+  test('array shape: accepts pronunciation/ipa as phonetic aliases', async () => {
+    const src = fromJson(
+      JSON.stringify([
+        {word: 'a', definition: 'd', pronunciation: 'AY'},
+        {word: 'b', definition: 'd', ipa: 'biː'},
+        {word: 'c', definition: 'd', phon: 'see'},
+      ]),
+    );
+    expect((await src.lookup('a'))?.phonetic).toBe('AY');
+    expect((await src.lookup('b'))?.phonetic).toBe('biː');
+    expect((await src.lookup('c'))?.phonetic).toBe('see');
+  });
+
+  test('array shape: blank/whitespace phonetic is treated as absent', async () => {
+    const src = fromJson(
+      JSON.stringify([
+        {word: 'a', definition: 'd', phonetic: '   '},
+        {word: 'b', definition: 'd', phonetic: ''},
+      ]),
+    );
+    expect(await src.lookup('a')).not.toHaveProperty('phonetic');
+    expect(await src.lookup('b')).not.toHaveProperty('phonetic');
+  });
+
+  test('array shape: non-string phonetic is ignored', async () => {
+    const src = fromJson(
+      JSON.stringify([{word: 'a', definition: 'd', phonetic: 42}]),
+    );
+    expect(await src.lookup('a')).not.toHaveProperty('phonetic');
+  });
+
+  test('object-map shape: never produces a phonetic (no place to put it)', async () => {
+    const src = fromJson(JSON.stringify({apple: 'fruit'}));
+    const hit = await src.lookup('apple');
+    expect(hit).toEqual({word: 'apple', definition: 'fruit', format: 'plain'});
+    expect(hit).not.toHaveProperty('phonetic');
+  });
+
   test('lazy: loader fires once across many lookups', async () => {
     const loadBytes = jest.fn(async () => enc(JSON.stringify({apple: 'fruit'})));
     const src = createJsonDictSource({name: 'test', loadBytes});

--- a/__tests__/userDictDiscovery.test.ts
+++ b/__tests__/userDictDiscovery.test.ts
@@ -229,6 +229,100 @@ describe('discoverUserDicts', () => {
     expect(sources[0].name).toBe('Pretty Name');
   });
 
+  test('meta.json csv.phoneticCol routes a third column into DictEntry.phonetic', async () => {
+    const deps = baseDeps({
+      [`${ROOT}/dune/glossary.csv`]: enc(
+        'ARRAKIS,the planet known as Dune,uh-RAK-is\n',
+      ),
+      [`${ROOT}/dune/meta.json`]: enc(
+        JSON.stringify({name: 'Dune', csv: {phoneticCol: 2}}),
+      ),
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(sources.length).toBe(1);
+    expect(sources[0].name).toBe('Dune');
+    const hit = await sources[0].lookup('arrakis');
+    expect(hit?.phonetic).toBe('uh-RAK-is');
+    expect(hit?.definition).toBe('the planet known as Dune');
+  });
+
+  test('meta.json csv config: hasHeader skips the first row', async () => {
+    const deps = baseDeps({
+      [`${ROOT}/g/words.csv`]: enc('term,definition,phonetic\napple,fruit,AP-ul\n'),
+      [`${ROOT}/g/meta.json`]: enc(
+        JSON.stringify({csv: {phoneticCol: 2, hasHeader: true}}),
+      ),
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(await sources[0].lookup('term')).toBeNull();
+    const apple = await sources[0].lookup('apple');
+    expect(apple?.phonetic).toBe('AP-ul');
+  });
+
+  test('meta.json csv config: headwordCol + definitionCol re-route to other columns', async () => {
+    // CSV with id, term, definition, phonetic — headword is col 1,
+    // definition col 2, phonetic col 3.
+    const deps = baseDeps({
+      [`${ROOT}/g/words.csv`]: enc('1,arrakis,the planet,uh-RAK-is\n'),
+      [`${ROOT}/g/meta.json`]: enc(
+        JSON.stringify({
+          csv: {
+            headwordCol: 1,
+            definitionCol: 2,
+            phoneticCol: 3,
+          },
+        }),
+      ),
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(await sources[0].lookup('1')).toBeNull();
+    const hit = await sources[0].lookup('arrakis');
+    expect(hit?.definition).toBe('the planet');
+    expect(hit?.phonetic).toBe('uh-RAK-is');
+  });
+
+  test('meta.json with a non-object root is ignored, defaults apply', async () => {
+    // E.g. someone writes `[]` or `"name"` at the root. We tolerate
+    // it instead of crashing — fall back to folder name + defaults.
+    const deps = baseDeps({
+      [`${ROOT}/g/words.csv`]: enc('apple,fruit\n'),
+      [`${ROOT}/g/meta.json`]: enc(JSON.stringify([])),
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(sources[0].name).toBe('g');
+    expect((await sources[0].lookup('apple'))?.definition).toBe('fruit');
+  });
+
+  test('meta.json csv config: invalid types are dropped, defaults survive', async () => {
+    // Garbage values shouldn't crash discovery — they fall back to
+    // the source's own defaults.
+    const deps = baseDeps({
+      [`${ROOT}/g/words.csv`]: enc('apple,fruit\n'),
+      [`${ROOT}/g/meta.json`]: enc(
+        JSON.stringify({
+          csv: {
+            headwordCol: 'zero',
+            definitionCol: -1,
+            phoneticCol: 1.5,
+            hasHeader: 'yes',
+          },
+        }),
+      ),
+    });
+    const sources = await discoverUserDicts(deps);
+    expect((await sources[0].lookup('apple'))?.definition).toBe('fruit');
+  });
+
+  test('meta.json without a csv field still yields a working CSV source', async () => {
+    const deps = baseDeps({
+      [`${ROOT}/g/words.csv`]: enc('apple,fruit\n'),
+      [`${ROOT}/g/meta.json`]: enc(JSON.stringify({name: 'G'})),
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(sources[0].name).toBe('G');
+    expect((await sources[0].lookup('apple'))?.definition).toBe('fruit');
+  });
+
   test('falls back to folder name when meta.json is malformed', async () => {
     const deps = baseDeps({
       [`${ROOT}/folder-name/words.csv`]: enc('apple,fruit\n'),

--- a/src/core/dict/csvDictSource.ts
+++ b/src/core/dict/csvDictSource.ts
@@ -1,7 +1,9 @@
 // CSV-backed DictSource. Two columns by default: headword (col 0)
 // and definition (col 1). Configurable for files with extra
-// metadata columns. Quoted fields and embedded commas / newlines /
-// escaped quotes are handled per RFC 4180.
+// metadata columns — including an optional phonetic column that
+// gets rendered under the headword in the popup. Quoted fields and
+// embedded commas / newlines / escaped quotes are handled per RFC
+// 4180.
 //
 // Lookup is case-insensitive. First occurrence of a key wins (later
 // duplicates are ignored), matching StarDict's behaviour.
@@ -17,8 +19,13 @@ export type CsvDictDeps = {
   name: string;
   loadBytes: LoadBytes;
   // Column indices (0-based). Defaults: headword=0, definition=1.
+  // phoneticCol is opt-in: a number selects that column as the
+  // pronunciation field; omitted (or out-of-range / empty in a row)
+  // means no phonetic. Set via meta.json by users whose CSVs carry
+  // a third column (term, def, phonetic).
   headwordCol?: number;
   definitionCol?: number;
+  phoneticCol?: number;
   // True = first row is a header and is skipped at parse time.
   hasHeader?: boolean;
   // Reject files larger than this. Default 10 MB. Tuned to the
@@ -93,17 +100,21 @@ const parseRow = (
   }
 };
 
+type CsvRow = {word: string; definition: string; phonetic?: string};
+
 type ParsedCsv = {
-  // Lowercase headword -> {canonical word, definition}.
-  index: Map<string, {word: string; definition: string}>;
+  // Lowercase headword -> {canonical word, definition, phonetic?}.
+  index: Map<string, CsvRow>;
 };
 
 const buildCsv = (
-  deps: Required<Pick<CsvDictDeps, 'headwordCol' | 'definitionCol' | 'hasHeader'>>,
+  deps: Required<
+    Pick<CsvDictDeps, 'headwordCol' | 'definitionCol' | 'hasHeader'>
+  > & {phoneticCol: number | undefined},
 ) =>
   (bytes: Uint8Array): ParsedCsv => {
     const text = decodeText(bytes);
-    const index = new Map<string, {word: string; definition: string}>();
+    const index = new Map<string, CsvRow>();
     let cursor = 0;
     let rowIdx = 0;
     while (cursor < text.length) {
@@ -121,7 +132,14 @@ const buildCsv = (
       }
       const key = normalizeKey(word);
       if (key.length > 0 && !index.has(key)) {
-        index.set(key, {word, definition});
+        const row: CsvRow = {word, definition};
+        if (deps.phoneticCol !== undefined) {
+          const phonetic = next.row[deps.phoneticCol]?.trim() ?? '';
+          if (phonetic.length > 0) {
+            row.phonetic = phonetic;
+          }
+        }
+        index.set(key, row);
       }
     }
     return {index};
@@ -129,9 +147,18 @@ const buildCsv = (
 
 const lookupCsv = (parsed: ParsedCsv, word: string): DictEntry | null => {
   const hit = parsed.index.get(normalizeKey(word));
-  return hit
-    ? {word: hit.word, definition: hit.definition, format: 'plain'}
-    : null;
+  if (!hit) {
+    return null;
+  }
+  const entry: DictEntry = {
+    word: hit.word,
+    definition: hit.definition,
+    format: 'plain',
+  };
+  if (hit.phonetic !== undefined) {
+    entry.phonetic = hit.phonetic;
+  }
+  return entry;
 };
 
 export const createCsvDictSource = (deps: CsvDictDeps): DictSource => {
@@ -139,6 +166,7 @@ export const createCsvDictSource = (deps: CsvDictDeps): DictSource => {
   const parseCsv = buildCsv({
     headwordCol: deps.headwordCol ?? 0,
     definitionCol: deps.definitionCol ?? 1,
+    phoneticCol: deps.phoneticCol,
     hasHeader: deps.hasHeader ?? false,
   });
   return createLazyAsyncSource<Uint8Array, ParsedCsv>({

--- a/src/core/dict/jsonDictSource.ts
+++ b/src/core/dict/jsonDictSource.ts
@@ -23,8 +23,10 @@ export type JsonDictDeps = {
 
 const DEFAULT_MAX_BYTES = 10 * 1024 * 1024;
 
+type JsonRow = {word: string; definition: string; phonetic?: string};
+
 type ParsedJson = {
-  index: Map<string, {word: string; definition: string}>;
+  index: Map<string, JsonRow>;
 };
 
 const pickHeadword = (row: Record<string, unknown>): string | undefined => {
@@ -49,22 +51,43 @@ const pickDefinition = (row: Record<string, unknown>): string | undefined => {
   return undefined;
 };
 
+// Recognise the common spellings users (and AI agents asked to
+// produce a glossary) reach for first. Whichever shows up first
+// wins. Trimmed; empty strings are treated as absent.
+const pickPhonetic = (row: Record<string, unknown>): string | undefined => {
+  const candidates = ['phonetic', 'pronunciation', 'ipa', 'phon'];
+  for (const k of candidates) {
+    const v = row[k];
+    if (typeof v === 'string') {
+      const trimmed = v.trim();
+      if (trimmed.length > 0) {
+        return trimmed;
+      }
+    }
+  }
+  return undefined;
+};
+
 const isPlainObject = (v: unknown): v is Record<string, unknown> =>
   typeof v === 'object' && v !== null && !Array.isArray(v);
 
 const buildJson = (bytes: Uint8Array): ParsedJson => {
   const text = decodeText(bytes);
   const data: unknown = JSON.parse(text);
-  const index = new Map<string, {word: string; definition: string}>();
+  const index = new Map<string, JsonRow>();
 
-  const insert = (word: string, definition: string): void => {
+  const insert = (word: string, definition: string, phonetic?: string): void => {
     const w = word.trim();
     if (w.length === 0) {
       return;
     }
     const key = normalizeKey(w);
     if (key.length > 0 && !index.has(key)) {
-      index.set(key, {word: w, definition});
+      const row: JsonRow = {word: w, definition};
+      if (phonetic !== undefined) {
+        row.phonetic = phonetic;
+      }
+      index.set(key, row);
     }
   };
 
@@ -75,8 +98,9 @@ const buildJson = (bytes: Uint8Array): ParsedJson => {
       }
       const w = pickHeadword(row);
       const d = pickDefinition(row);
+      const p = pickPhonetic(row);
       if (typeof w === 'string' && typeof d === 'string') {
-        insert(w, d);
+        insert(w, d, p);
       }
     }
   } else if (isPlainObject(data)) {
@@ -94,9 +118,18 @@ const buildJson = (bytes: Uint8Array): ParsedJson => {
 
 const lookupJson = (parsed: ParsedJson, word: string): DictEntry | null => {
   const hit = parsed.index.get(normalizeKey(word));
-  return hit
-    ? {word: hit.word, definition: hit.definition, format: 'plain'}
-    : null;
+  if (!hit) {
+    return null;
+  }
+  const entry: DictEntry = {
+    word: hit.word,
+    definition: hit.definition,
+    format: 'plain',
+  };
+  if (hit.phonetic !== undefined) {
+    entry.phonetic = hit.phonetic;
+  }
+  return entry;
 };
 
 export const createJsonDictSource = (deps: JsonDictDeps): DictSource => {

--- a/src/core/dict/userDictDiscovery.ts
+++ b/src/core/dict/userDictDiscovery.ts
@@ -7,11 +7,23 @@
 // Folder layout, per dict:
 //
 //   <SnDict-root>/<name>/
-//     ├── meta.json                      (optional; just `{name}` today)
+//     ├── meta.json                      (optional)
 //     ├── *.ifo + *.idx + *.dict[.dz]    -> StarDict
 //     ├── *.csv                          -> CSV
 //     ├── *.json                         -> JSON
 //     └── *.mdx                          -> logged as deferred (skipped)
+//
+// meta.json schema (all fields optional):
+//
+//   {
+//     "name": "Display Name",
+//     "csv": {
+//       "headwordCol": 0,
+//       "definitionCol": 1,
+//       "phoneticCol": 2,
+//       "hasHeader": false
+//     }
+//   }
 //
 // Per-folder failures are isolated and logged — one bad dict folder
 // doesn't break discovery for the others.
@@ -93,28 +105,84 @@ const basenameOf = (path: string): string => {
   return slash >= 0 ? path.slice(slash + 1) : path;
 };
 
-const readMetaName = async (
+type CsvMetaConfig = {
+  headwordCol?: number;
+  definitionCol?: number;
+  phoneticCol?: number;
+  hasHeader?: boolean;
+};
+
+type FolderMeta = {
+  name?: string;
+  csv?: CsvMetaConfig;
+};
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+  typeof v === 'object' && v !== null && !Array.isArray(v);
+
+// Pick a non-negative integer field from a parsed meta blob. Anything
+// non-numeric, negative, or non-integer is dropped — there's no
+// meaningful interpretation, and silently ignoring lets a typo in
+// meta.json fall back to defaults instead of crashing discovery.
+const pickNonNegInt = (
+  obj: Record<string, unknown>,
+  key: string,
+): number | undefined => {
+  const v = obj[key];
+  if (typeof v !== 'number' || !Number.isInteger(v) || v < 0) {
+    return undefined;
+  }
+  return v;
+};
+
+const parseCsvMeta = (raw: unknown): CsvMetaConfig | undefined => {
+  if (!isPlainObject(raw)) {
+    return undefined;
+  }
+  const cfg: CsvMetaConfig = {};
+  const hw = pickNonNegInt(raw, 'headwordCol');
+  if (hw !== undefined) {
+    cfg.headwordCol = hw;
+  }
+  const def = pickNonNegInt(raw, 'definitionCol');
+  if (def !== undefined) {
+    cfg.definitionCol = def;
+  }
+  const phon = pickNonNegInt(raw, 'phoneticCol');
+  if (phon !== undefined) {
+    cfg.phoneticCol = phon;
+  }
+  if (typeof raw.hasHeader === 'boolean') {
+    cfg.hasHeader = raw.hasHeader;
+  }
+  return cfg;
+};
+
+const readFolderMeta = async (
   files: FileEntry[],
   fetchFn: typeof fetch,
-): Promise<string | undefined> => {
+): Promise<FolderMeta> => {
   const meta = files.find(f => f.type === 1 && basenameOf(f.path) === 'meta.json');
   if (!meta) {
-    return undefined;
+    return {};
   }
   try {
     const text = decodeUtf8(await fetchAsUint8(meta.path, fetchFn));
-    const parsed = JSON.parse(text) as unknown;
-    if (
-      parsed !== null &&
-      typeof parsed === 'object' &&
-      typeof (parsed as {name?: unknown}).name === 'string' &&
-      (parsed as {name: string}).name.trim().length > 0
-    ) {
-      return (parsed as {name: string}).name.trim();
+    const parsed: unknown = JSON.parse(text);
+    if (!isPlainObject(parsed)) {
+      return {};
     }
-    return undefined;
+    const out: FolderMeta = {};
+    if (typeof parsed.name === 'string' && parsed.name.trim().length > 0) {
+      out.name = parsed.name.trim();
+    }
+    const csv = parseCsvMeta(parsed.csv);
+    if (csv !== undefined) {
+      out.csv = csv;
+    }
+    return out;
   } catch {
-    return undefined;
+    return {};
   }
 };
 
@@ -233,8 +301,8 @@ const buildSourceForFolder = async (
     return null;
   }
 
-  const metaName = await readMetaName(files, fetchFn);
-  const displayName = metaName ?? folderName;
+  const meta = await readFolderMeta(files, fetchFn);
+  const displayName = meta.name ?? folderName;
 
   if (detected.kind === 'stardict') {
     const synPath = detected.syn;
@@ -267,6 +335,10 @@ const buildSourceForFolder = async (
     return createCsvDictSource({
       name: displayName,
       loadBytes: () => fetchAsArrayBuffer(detected.path, fetchFn),
+      headwordCol: meta.csv?.headwordCol,
+      definitionCol: meta.csv?.definitionCol,
+      phoneticCol: meta.csv?.phoneticCol,
+      hasHeader: meta.csv?.hasHeader,
       logger,
     });
   }

--- a/src/core/lookup.ts
+++ b/src/core/lookup.ts
@@ -26,6 +26,12 @@ export type DictEntry = {
   word: string;
   definition: string;
   format: DefinitionFormat;
+  // Optional phonetic transcription (IPA, respelling, Herbert-style
+  // syllable stress markers, etc.). Sources fill this when the data
+  // they read carries a separate pronunciation field; the popup
+  // renders it under the headword. Absent for sources that only
+  // know word + definition.
+  phonetic?: string;
 };
 
 // One source's contribution to the result. `source` is the name of

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -28,7 +28,8 @@ export type StringId =
   | 'popup.loading'
   | 'popup.recognizing'
   | 'popup.fontSmaller'
-  | 'popup.fontLarger';
+  | 'popup.fontLarger'
+  | 'popup.pronunciation';
 
 // Locale codes use the firmware's convention: en, zh_CN, zh_TW, ja,
 // th, nl. Underscore (not hyphen) matches PluginButton.nameMap shape
@@ -43,6 +44,7 @@ const STRINGS: Record<string, Partial<Record<StringId, string>>> = {
     'popup.recognizing': 'Recognizing…',
     'popup.fontSmaller': 'Decrease text size',
     'popup.fontLarger': 'Increase text size',
+    'popup.pronunciation': 'Pronunciation',
   },
   zh_CN: {
     'popup.synonyms': '同义词',
@@ -53,6 +55,7 @@ const STRINGS: Record<string, Partial<Record<StringId, string>>> = {
     'popup.recognizing': '识别中…',
     'popup.fontSmaller': '缩小文字',
     'popup.fontLarger': '放大文字',
+    'popup.pronunciation': '发音',
   },
   zh_TW: {
     'popup.synonyms': '同義詞',
@@ -63,6 +66,7 @@ const STRINGS: Record<string, Partial<Record<StringId, string>>> = {
     'popup.recognizing': '辨識中…',
     'popup.fontSmaller': '縮小文字',
     'popup.fontLarger': '放大文字',
+    'popup.pronunciation': '發音',
   },
   ja: {
     'popup.synonyms': '類義語',
@@ -73,6 +77,7 @@ const STRINGS: Record<string, Partial<Record<StringId, string>>> = {
     'popup.recognizing': '認識中…',
     'popup.fontSmaller': '文字を小さく',
     'popup.fontLarger': '文字を大きく',
+    'popup.pronunciation': '発音',
   },
   th: {
     'popup.synonyms': 'คำพ้องความหมาย',
@@ -83,6 +88,7 @@ const STRINGS: Record<string, Partial<Record<StringId, string>>> = {
     'popup.recognizing': 'กำลังรู้จำ…',
     'popup.fontSmaller': 'ลดขนาดตัวอักษร',
     'popup.fontLarger': 'เพิ่มขนาดตัวอักษร',
+    'popup.pronunciation': 'การออกเสียง',
   },
   nl: {
     'popup.synonyms': 'Synoniemen',
@@ -93,6 +99,7 @@ const STRINGS: Record<string, Partial<Record<StringId, string>>> = {
     'popup.recognizing': 'Bezig met herkennen…',
     'popup.fontSmaller': 'Tekst verkleinen',
     'popup.fontLarger': 'Tekst vergroten',
+    'popup.pronunciation': 'Uitspraak',
   },
   de: {
     'popup.synonyms': 'Synonyme',
@@ -103,6 +110,7 @@ const STRINGS: Record<string, Partial<Record<StringId, string>>> = {
     'popup.recognizing': 'Wird erkannt…',
     'popup.fontSmaller': 'Schrift verkleinern',
     'popup.fontLarger': 'Schrift vergrößern',
+    'popup.pronunciation': 'Aussprache',
   },
 };
 

--- a/src/ui/DefinitionPopup.tsx
+++ b/src/ui/DefinitionPopup.tsx
@@ -112,6 +112,13 @@ export default function DefinitionPopup(): React.JSX.Element {
   // still shows something meaningful.
   const headerWord =
     hits.length > 0 ? hits[0].entry.word : state.result.queriedFor;
+  // Phonetic comes from the first hit that supplies one. Walking the
+  // list (rather than strictly hits[0]) means a multi-dict lookup
+  // where the first source — say, WordNet — has no phonetic but a
+  // user CSV does, still surfaces the phonetic in the header. The
+  // first wins; later disagreements stay visible per-source in their
+  // section bodies.
+  const headerPhonetic = hits.find(h => h.entry.phonetic)?.entry.phonetic;
   // Show source badges as soon as we have ≥2 distinct things to show
   // (hits + loading combined), so the layout doesn't reflow when a
   // loading section flips to a hit.
@@ -169,6 +176,17 @@ export default function DefinitionPopup(): React.JSX.Element {
             </Pressable>
           </View>
         </View>
+        {headerPhonetic ? (
+          <Text
+            style={[
+              styles.phonetic,
+              {fontSize: styles.phonetic.fontSize * fontScale},
+            ]}
+            accessibilityLabel={`${t('popup.pronunciation')}: ${headerPhonetic}`}
+            numberOfLines={1}>
+            {headerPhonetic}
+          </Text>
+        ) : null}
         {state.ocrLabel ? (
           <Text style={styles.ocrLabel}>{state.ocrLabel}</Text>
         ) : null}

--- a/src/ui/popupStyles.ts
+++ b/src/ui/popupStyles.ts
@@ -33,6 +33,16 @@ export const popupStyles = StyleSheet.create({
     fontSize: 14,
     color: '#555555',
   },
+  // Phonetic line under the headword. Italic + medium grey so it
+  // reads as supplementary chrome (like a real dictionary), not body
+  // copy. Sized between the OCR label and the definition body so
+  // it's clearly secondary to the headword but still scannable.
+  phonetic: {
+    marginTop: 2,
+    fontSize: 16,
+    fontStyle: 'italic',
+    color: '#555555',
+  },
   body: {
     marginTop: 12,
     marginBottom: 16,


### PR DESCRIPTION
## Summary
- Adds first-class phonetic support: CSV `phoneticCol` + JSON `phonetic|pronunciation|ipa|phon` aliases surface a pronunciation under the headword in the popup.
- Discovery learns the column from a small `meta.json` schema extension (`csv: { headwordCol, definitionCol, phoneticCol, hasHeader }`); invalid types fall back to defaults.
- Popup renders an italic phonetic line that scales with the user-selected font size and exposes a localised `"Pronunciation: ..."` accessibilityLabel. Header walks `hits[]` so a CSV's phonetic still wins when WordNet (no phonetic) is hits[0]. Multi-source disagreement rule is pinned: first hit with a phonetic wins.
- i18n: `popup.pronunciation` translated for en, zh_CN, zh_TW, ja, th, nl, de.

## User-facing example
```
SnDict/
  Dune/
    Dune_with_phonetics.csv      term, definition, phonetic
    meta.json                    {"name":"Dune","csv":{"phoneticCol":2}}
```
Looking up `arrakis` shows `ARRAKIS` with `uh-RAK-is` italicised under it.

## Out of scope
- StarDict `t` (phonetic) type in `sametypesequence` — touches the binary parser; tracked as a follow-up.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` — 541 passing (+19 new)
- [x] `npm run coverage` — branches 97.25%, above the 97% gate
- [x] `npx tsc --noEmit` — zero new errors over master
- [ ] Manual on-device check: drop a 3-column CSV + meta.json into `MyStyle/SnDict/<Folder>/`, verify the phonetic line renders under the headword and scales with A−/A+
- [ ] VoiceOver/TalkBack reads "Pronunciation: …" rather than the raw respelling