### PR TITLE
rel8: Wikdict <div> un-glue, CSV/JSON freeze fixes, root meta.json plumbing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,17 @@ jobs:
       - name: Test
         run: npx jest
 
+      - name: Real-StarDict regression suite
+        # MANDATORY release gate. Downloads the StarDicts pinned in
+        # __tests__/integration/manifest.ts, SHA-verifies them, runs
+        # the full StarDict→htmlToPlainText pipeline against real
+        # entries (Gestirn, chien, Buch, …), then cleans up. A
+        # non-zero exit blocks the release. If wikdict.com is
+        # unreachable, the release is blocked deliberately — we'd
+        # rather not ship without confirming real upstream content
+        # still renders correctly.
+        run: npm run test:integration
+
       - name: Determine release version
         id: ver
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,8 @@ src/core/dict/data/baseDictData.ts
 
 # Local logcat dumps used while debugging on-device sessions.
 logcat.txt
+
+# Integration-test scratch space — populated by scripts/runIntegrationTests.mjs
+# (downloaded StarDict zips + extracts, removed automatically after each run
+# unless --keep is passed).
+.cache/

--- a/README.md
+++ b/README.md
@@ -147,11 +147,13 @@ Concrete copy-pasteable starting points live at [`assets/sample-dicts/`](assets/
 
 ### Where to find dictionaries
 
-Most users won't author a StarDict from scratch — there are huge corpora of pre-built dicts in the wild. Three sources cover the long tail:
+Most users won't author a StarDict from scratch — there are huge corpora of pre-built dicts in the wild. Five sources cover the long tail:
 
 - **[FreeDict](https://freedict.org/)** — open-source bilingual dictionaries, native StarDict format, MIT/CC-licensed. Direct downloads at [freedict.org/freedict-database.json](https://freedict.org/freedict-database.json) (machine-readable) or browse the per-language pages. Covers German, French, Italian, Spanish, Portuguese, Dutch, Russian, Japanese, Czech, Polish, Hungarian, Swedish, Turkish, Arabic, Hebrew, and more.
-- **[Wiktionary-Dictionaries (Vuizur)](https://github.com/Vuizur/Wiktionary-Dictionaries)** — actively-maintained Wiktionary dumps converted to StarDict, ~100+ language pairs including monolingual entries. CC-BY-SA. The most comprehensive single source for non-English content.
-- **[huzheng.org](http://download.huzheng.org/)** — the historical StarDict archive. Heavy on Chinese and Japanese options; mixed licensing (check each entry). Site is occasionally slow or down — Wiktionary-Dictionaries is the modern alternative for most languages.
+- **[WikDict](https://download.wikdict.com/dictionaries/stardict/)** — translation dictionaries between non-English language pairs (de↔fr, fr↔de, it↔es, la↔fr, …) plus FreeDict cross-language pairs, derived from Wiktionary via DBnary. CC-BY-SA. Particularly useful for language learners who want a non-English source/target without going through English. Native StarDict format.
+- **[xxyzz/wiktionary_stardict](https://xxyzz.github.io/wiktionary_stardict/)** — Wiktionary-derived StarDict bundles for 100+ language pairs, including monolingual heavyweight dicts (~100 MB+ for full-language Wiktionaries). Actively maintained. Native StarDict format, CC-BY-SA. *(Thanks to [@alioth9](https://github.com/alioth9) for the pointer.)*
+- **[Wiktionary-Dictionaries (Vuizur)](https://github.com/Vuizur/Wiktionary-Dictionaries)** — actively-maintained Wiktionary dumps converted to StarDict, ~100+ language pairs including monolingual entries. CC-BY-SA. Comparable to xxyzz's collection — try whichever has better coverage for your specific pair.
+- **[huzheng.org](http://download.huzheng.org/)** — the historical StarDict archive. Heavy on Chinese and Japanese options; mixed licensing (check each entry). Site is occasionally slow or down — Wiktionary-Dictionaries / xxyzz are the modern alternatives for most languages.
 
 #### Quick pointers per language
 
@@ -161,9 +163,9 @@ Most users won't author a StarDict from scratch — there are huge corpora of pr
 | **Japanese (ja)** | JMdict / EDICT (Japanese ↔ English) on huzheng or Vuizur. KANJIDIC for kanji-specific lookups. |
 | **Italian (it)** | FreeDict `eng-ita` and `ita-eng` for bilingual; Wiktionary it on Vuizur for monolingual definitions. |
 | **Dutch (nl)** | FreeDict `eng-nld` and `nld-eng`; Wiktionary nl on Vuizur. |
-| **German (de)** | FreeDict `eng-deu` and `deu-eng` for bilingual; Wiktionary de on Vuizur for monolingual. |
-| **French (fr)** | FreeDict `eng-fra` and `fra-eng`; Wiktionary fr on Vuizur. |
-| **Spanish (es)** | FreeDict `eng-spa` and `spa-eng`; Wiktionary es on Vuizur. |
+| **German (de)** | FreeDict `eng-deu` and `deu-eng` for bilingual via English; **WikDict `de-fr`/`fr-de`** or `de-es`/`es-de` for direct non-English pairs; Wiktionary de on Vuizur or xxyzz for monolingual. |
+| **French (fr)** | FreeDict `eng-fra` and `fra-eng`; WikDict has `fr-de`, `fr-it`, `fr-es`, `la-fr`; Wiktionary fr on Vuizur or xxyzz. |
+| **Spanish (es)** | FreeDict `eng-spa` and `spa-eng`; WikDict has `es-de`, `es-it`, `es-fr`; Wiktionary es on Vuizur or xxyzz. |
 | **Russian (ru)** | FreeDict `eng-rus` and `rus-eng`; Wiktionary ru on Vuizur. |
 | **Korean (ko)** | Wiktionary ko on Vuizur. |
 | **Polish, Czech, Hungarian, Swedish, Portuguese, Turkish, Arabic, Hebrew, …** | FreeDict has bilingual pairs against English; Wiktionary-Dictionaries has monolingual + many cross-language pairs. |
@@ -171,6 +173,7 @@ Most users won't author a StarDict from scratch — there are huge corpora of pr
 #### A few notes worth knowing before you grab one
 
 - **Most downloads ship as `.tar.bz2` or `.zip`.** Extract first, then drop the resulting folder (or its files) into `MyStyle/SnDict/`. A typical extracted layout matches the organised layout described above — `.ifo` + `.idx` + `.dict.dz` together.
+- **Wikdict / Wiktionary-derived dicts use HTML formatting** (`sametypesequence=h` in the `.ifo`). The popup strips the tags and lays out the resulting blocks — IPA on its own line, part-of-speech on its own line, definition body, then translations on separate lines. v1.0.6 and earlier had a bug where translation blocks (`<div>...</div>`) glued to the definition text above (e.g. `…sichtbar istastre`); v1.0.7+ renders them on their own lines correctly.
 - **Licensing.** For personal use on your own device, every source above is fine. If you plan to redistribute (e.g., bundle into a custom `.snplg`), check the per-dict license — FreeDict is permissive, Wiktionary-derived dicts are CC-BY-SA, huzheng entries vary.
 - **Morphology / inflected forms.** Highly inflected languages (German declensions, Italian conjugations) are only as good as the dict's headword coverage. Wiktionary-derived dicts generally include inflected forms; FreeDict's coverage varies. If lassoing `Häuser` returns "no entry," try lassoing the lemma `Haus` to confirm the dict simply lacks form folding rather than your sideloading being broken.
 - **If you have a dict in a different format** (MDX, EPUB-based, SDictionary, Babylon, …), [`pyglossary`](https://github.com/ilius/pyglossary) is the gold-standard CLI converter — it reads ~50 formats and writes StarDict. One-line install via `pip install pyglossary`, then `pyglossary --read-format=mdx --write-format=stardict input.mdx`.
@@ -301,6 +304,18 @@ To regenerate the coverage report:
 ```sh
 npm run coverage
 ```
+
+## Real-StarDict regression suite
+
+```sh
+npm run test:integration
+```
+
+End-to-end tests that download real Wikdict StarDicts (German↔French, French↔German, German↔English), SHA-verify each archive against the pins in `__tests__/integration/manifest.ts`, run the full StarDict→`htmlToPlainText` pipeline against real entries (`Gestirn`, `Hund`, `chien`, `maison`, `Buch`, …), then auto-clean the cache. Pass `--keep` (`npm run test:integration -- --keep`) to retain the downloads in `.cache/integration-dicts/` while iterating on assertions.
+
+Why a separate command: the default `npm test` runs only the synthetic-fixture unit suite — fast, offline, deterministic. The integration suite needs network and ~12 MB of downloads, so it's opt-in for local development. **It is mandatory for releases**: `release.yml` runs it as a hard gate before producing any artifact, and a non-zero exit (test failure, SHA mismatch, or wikdict.com unreachable) blocks the release.
+
+To add a new dict to the suite, capture its SHA-256 (`shasum -a 256 file.zip`), add it to `MANIFEST` in `manifest.ts` with a few headword expectations, mirror the entry in `scripts/runIntegrationTests.mjs`'s `MANIFEST_MIRROR` (the runner checks for drift between the two and fails loudly on mismatch), and re-run.
 
 ## Linting
 

--- a/__tests__/csvDictSource.test.ts
+++ b/__tests__/csvDictSource.test.ts
@@ -1,4 +1,5 @@
 import {createCsvDictSource} from '../src/core/dict/csvDictSource';
+import {YIELD_PERIOD} from '../src/core/dict/yieldOften';
 
 const enc = (s: string) => new TextEncoder().encode(s).buffer;
 
@@ -285,6 +286,43 @@ describe('createCsvDictSource', () => {
     const src = fromCsv('ARRAKIS,the planet,uh-RAK-is\n');
     const hit = await src.lookup('arrakis');
     expect(hit).not.toHaveProperty('phonetic');
+  });
+
+  test('yields cooperatively while parsing a large CSV (UI-blocking guard)', async () => {
+    // Generate YIELD_PERIOD + a few rows so the parser hits at least
+    // one in-loop yield boundary. Without yielding, this loop would
+    // block input on Hermes for several seconds on multi-MB user
+    // CSVs — exactly the freeze users reported.
+    const total = YIELD_PERIOD + 5;
+    const lines: string[] = [];
+    for (let i = 0; i < total; i++) {
+      lines.push(`w${i},def${i}`);
+    }
+    const csv = lines.join('\n') + '\n';
+
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    try {
+      const src = fromCsv(csv);
+      // Trigger parse via a lookup (the harness lazy-loads).
+      const hit = await src.lookup('w0');
+      expect(hit?.definition).toBe('def0');
+      // Last row also kept — the loop yielded but resumed correctly.
+      const last = await src.lookup(`w${total - 1}`);
+      expect(last?.definition).toBe(`def${total - 1}`);
+      // Minimum yield budget: one after decodeText (boundary
+      // between native TextDecoder and JS iteration), plus one per
+      // YIELD_PERIOD rows during iteration. For total = period + 5
+      // that's 1 + 1 = 2. Asserting the floor catches a regression
+      // that drops EITHER the boundary yield or the in-loop yield —
+      // ≥1 would only catch the all-or-nothing case.
+      const zeroDelayCalls = setTimeoutSpy.mock.calls.filter(
+        c => c[1] === 0,
+      );
+      const expectedMin = 1 + Math.floor(total / YIELD_PERIOD);
+      expect(zeroDelayCalls.length).toBeGreaterThanOrEqual(expectedMin);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 
   test('lazy: loader fires once across many lookups', async () => {

--- a/__tests__/htmlToPlainText.test.ts
+++ b/__tests__/htmlToPlainText.test.ts
@@ -138,4 +138,97 @@ describe('htmlToPlainText', () => {
     const plain = 'A simple definition that uses no HTML at all.';
     expect(htmlToPlainText(plain)).toBe(plain);
   });
+
+  describe('Wikdict <div>-translation shape (issue #15)', () => {
+    // Verbatim definition extracted from wikdict-de-fr.zip's
+    // stardict.dict for headword "Gestirn" (offset 5002035, len 222).
+    // Wikdict wraps each translation in <div>...</div> directly after
+    // the German definition text, with no <br> or other separator —
+    // so v1.0.6's renderer concatenated "ist" and "astre" into
+    // "istastre". This test pins the fix.
+    const wikdictGestirn =
+      '<div>/<font color="gray">ɡəˈʃtɪʁn</font>/<br>\n' +
+      '<font color="green">noun, neutral</font><br>' +
+      'Astronomie, gehoben, meist im Plural: Himmelskörper im ' +
+      'Allgemeinen, welcher am Nachthimmel sichtbar ist' +
+      '<div>astre</div></div>';
+
+    test('does not glue definition text to the following <div> translation', () => {
+      const out = htmlToPlainText(wikdictGestirn);
+      // The smoking-gun regression: "istastre" must not appear.
+      expect(out).not.toMatch(/istastre/);
+      // Translation appears separated from the definition body.
+      expect(out).toMatch(/sichtbar ist\s*\n+\s*astre/);
+    });
+
+    test('preserves all upstream content (IPA, POS, definition, translation)', () => {
+      const out = htmlToPlainText(wikdictGestirn);
+      expect(out).toContain('ɡəˈʃtɪʁn');
+      expect(out).toContain('noun, neutral');
+      expect(out).toContain(
+        'Astronomie, gehoben, meist im Plural: Himmelskörper im Allgemeinen',
+      );
+      expect(out).toContain('astre');
+    });
+
+    test('outer <div> wrapper does not produce a leading blank line', () => {
+      // The whole entry is wrapped in <div>...</div>; the open tag
+      // sits at position 0 with no prior content. The renderer must
+      // not emit a leading newline that would make the popup look
+      // like it had an empty first line.
+      const out = htmlToPlainText(wikdictGestirn);
+      expect(out.startsWith('\n')).toBe(false);
+    });
+
+    test('trailing &nbsp; before <div> still un-glues translation (NBSP variant)', () => {
+      // Belt-and-suspenders for the trailing-space heuristic. A
+      // future upstream shape with `&nbsp;` (decoded to U+00A0)
+      // immediately before <div>...</div> would, with a naive
+      // "skip space and tab only" walkback, still be treated as
+      // mid-text and gain a newline — but only because the NBSP
+      // itself isn't whitespace to that walker. The discriminator
+      // explicitly includes U+00A0 so the result is identical to
+      // the regular-space case.
+      const nbspBeforeDiv =
+        '<div>Definition body&nbsp;<div>translation</div></div>';
+      const out = htmlToPlainText(nbspBeforeDiv);
+      expect(out).toMatch(/Definition body\s*\n+\s*translation/);
+      expect(out).not.toMatch(/body translation/);
+    });
+
+    test('trailing-space-before-<div> variant still un-glues translation (e.g. "…ist <div>astre</div>")', () => {
+      // Defensive: a future Wikdict export might emit a trailing
+      // space between the definition text and the translation block.
+      // The naive "skip newline if last char is whitespace" rule
+      // would still glue these as `…ist astre` (joined with just a
+      // space). The implementation looks past trailing spaces at the
+      // last meaningful character, so the newline still fires.
+      const trailingSpace =
+        '<div>Astronomie: Himmelskörper, welcher am Nachthimmel sichtbar ist ' +
+        '<div>astre</div></div>';
+      const out = htmlToPlainText(trailingSpace);
+      // Translation appears on a fresh line, not glued behind a
+      // single space.
+      expect(out).toMatch(/sichtbar ist\s*\n+\s*astre/);
+      expect(out).not.toMatch(/ist astre/);
+    });
+
+    test('multi-translation entries (Wikdict <ol><li><div>...</div></li>) keep bullets and break translations onto their own lines', () => {
+      // Real-world shape from wikdict-de-fr "Hund": two translations
+      // under the same sense, each in <li><div>...</div></li>. The
+      // bullet must survive (• chien on its own line) AND the bullets
+      // must not glue to surrounding text.
+      const wikdictHund =
+        '<div><font color="green">noun, male</font><br><ol>' +
+        '<li>Haustier, dessen Vorfahre der Wolf ist<ol>' +
+        '<li><div>chien</div></li>' +
+        '<li><div>chienne</div></li>' +
+        '</ol></li></ol></div>';
+      const out = htmlToPlainText(wikdictHund);
+      expect(out).toContain('• chien');
+      expect(out).toContain('• chienne');
+      // Bullets are on separate lines (not "• chien• chienne").
+      expect(out).toMatch(/• chien\s*\n\s*• chienne/);
+    });
+  });
 });

--- a/__tests__/integration/manifest.ts
+++ b/__tests__/integration/manifest.ts
@@ -1,0 +1,135 @@
+// Real-StarDict regression manifest. Listed dicts are downloaded by
+// scripts/runIntegrationTests.mjs into .cache/integration-dicts/<name>/,
+// SHA-256 verified against the pins below, then exercised by
+// wikdictRegression.test.ts.
+//
+// To add a dict:
+//   1. Pick a stable upstream URL (CC-BY-SA preferred).
+//   2. Download once locally and `shasum -a 256 <file>` to capture
+//      the pin. Hard-pinning means a future upstream rebuild fails
+//      the suite loudly instead of silently letting a regression in.
+//   3. Sample a few headwords (any node script that walks the .idx
+//      and slices the .dict by offset/length works) and add their
+//      expected substrings + glue regressions.
+//   4. Re-run `npm run test:integration`.
+//
+// Why pin the SHA: Wikdict rebuilds quarterly. If a rebuild changes
+// the HTML shape (extra <span>, restructured <div>, etc.), the pin
+// fires before the assertions do — that's the signal to update both
+// the pin AND verify the assertions still hold.
+
+export type WordExpectation = {
+  // Headword to look up. Lookup is case-insensitive; we normalise
+  // upstream so any of `Gestirn`/`gestirn`/`GESTIRN` works.
+  word: string;
+  // Substrings the rendered (htmlToPlainText'd) definition must
+  // contain. Keep them short and stable — no full sentences, just
+  // distinctive fragments unlikely to change across Wikdict
+  // rebuilds.
+  contains: string[];
+  // Substrings the rendered output must NOT contain. Use these to
+  // pin the bug shape: `istastre`, `Wolf istchien`, etc. — exact
+  // glued forms that v1.0.6 produced and v1.0.7+ must not.
+  notContains?: string[];
+  // Optional regex assertions. Useful for "translation appears on
+  // its own line" patterns that can't be expressed as substrings.
+  matches?: RegExp[];
+};
+
+export type DictManifest = {
+  // Cache key: also the subfolder name under .cache/integration-dicts/.
+  name: string;
+  // Direct download URL. Must be a `.zip` containing a single
+  // top-level directory with `stardict.ifo` + `stardict.idx` +
+  // `stardict.dict.dz`.
+  url: string;
+  // SHA-256 of the .zip. Pinned; the runner refuses to extract on
+  // mismatch and prints a remediation hint.
+  sha256: string;
+  // Friendly description shown in the test header.
+  description: string;
+  // Per-headword expectations. The test fails if any one entry
+  // doesn't satisfy all of its `contains` / `notContains` /
+  // `matches` rules, naming the offending dict + word.
+  entries: WordExpectation[];
+};
+
+export const MANIFEST: DictManifest[] = [
+  {
+    name: 'wikdict-de-fr',
+    url: 'https://download.wikdict.com/dictionaries/stardict/wikdict-de-fr.zip',
+    sha256:
+      '17d00ca43cd6e80089c66dd2959aff30535a355ba36c4d39d6537c0948d37c41',
+    description: 'WikDict German→French (Wiktionary-derived, CC-BY-SA)',
+    entries: [
+      {
+        // The exact entry from issue #15. Pre-fix output glued
+        // "ist" and "astre" into "istastre"; post-fix the
+        // translation lands on its own line.
+        word: 'Gestirn',
+        contains: [
+          'ɡəˈʃtɪʁn', // IPA
+          'noun, neutral', // POS
+          'Astronomie', // German definition body
+          'astre', // French translation
+        ],
+        notContains: ['istastre'],
+        matches: [/sichtbar ist\s*\n+\s*astre/],
+      },
+      {
+        // Multi-translation entry under <ol><li><div>...</div></li>.
+        // Bullets must survive AND each translation must be on its
+        // own line.
+        word: 'Hund',
+        contains: ['noun, male', '• chien', '• chienne'],
+        // Pre-fix forms: "ist<div>chien" produced "istchien" type
+        // glue; the bullets should never collapse into a single
+        // run of text.
+        notContains: ['istchien', 'chien• chienne'],
+        matches: [/• chien\s*\n\s*• chienne/],
+      },
+    ],
+  },
+  {
+    name: 'wikdict-fr-de',
+    url: 'https://download.wikdict.com/dictionaries/stardict/wikdict-fr-de.zip',
+    sha256:
+      '95f73aff4271c5eaf68d5c426b8fd1bc728880ead0e63b9e8cc84b9e934b3f68',
+    description: 'WikDict French→German (Wiktionary-derived, CC-BY-SA)',
+    entries: [
+      {
+        // The reverse-direction shape. The dict's case-insensitive
+        // first match for "chien" is the (Astrologie) zodiac entry,
+        // not the canine — both are present, and which is "first" is
+        // a property of the .idx ordering pinned by the SHA above.
+        // Either way, the glue invariant is what matters: definition
+        // body must not run into the German translation.
+        word: 'chien',
+        contains: ['ʃjɛ̃', 'Astrologie', 'zodiaque chinois', 'Hund'],
+        notContains: ['chinoisHund'],
+        matches: [/chinois\s*\n+\s*Hund/],
+      },
+      {
+        word: 'maison',
+        contains: ['mɛ.zɔ̃', 'adjective', 'Familier', 'hausgemacht'],
+        notContains: ['maisonhausgemacht'],
+        matches: [/maison\s*\n+\s*hausgemacht/],
+      },
+    ],
+  },
+  {
+    name: 'wikdict-de-en',
+    url: 'https://download.wikdict.com/dictionaries/stardict/wikdict-de-en.zip',
+    sha256:
+      'e84d6ec7a5e92f2232fe9c1fe04f149dd0b4defab47b879705d1a395138f5024',
+    description: 'WikDict German→English (Wiktionary-derived, CC-BY-SA)',
+    entries: [
+      {
+        word: 'Buch',
+        contains: ['buːx', 'noun, neutral', 'Schriftwerk', '• book'],
+        notContains: ['Blattgold<', 'Blattgoldbook'],
+        matches: [/• book/],
+      },
+    ],
+  },
+];

--- a/__tests__/integration/wikdictRegression.test.ts
+++ b/__tests__/integration/wikdictRegression.test.ts
@@ -1,0 +1,111 @@
+// End-to-end regression suite against real downloaded StarDicts.
+// Run via `npm run test:integration` — the runner script downloads
+// each manifest entry into .cache/integration-dicts/, SHA-verifies,
+// then invokes jest with SNDICT_INTEGRATION=1. Without that env var
+// the suite no-ops (so default `npm test` stays fast and offline).
+//
+// What this catches that synthetic-fixture unit tests don't:
+//   - Real upstream HTML shapes (Wikdict's `<div>` translation
+//     wrapping, `<font color="...">` for IPA + POS, nested
+//     `<ol>/<li><div>...</div></li>` for multi-sense translations).
+//   - Issue-#15-class glue regressions: a future change to the
+//     <div> handling in htmlToPlainText that re-introduces
+//     `istastre` immediately fails this suite against the actual
+//     Gestirn entry, not a hand-typed fixture.
+//   - Full pipeline integrity: dictzip random-access read, .idx
+//     parsing of a 50k+ entry dict, normalizeKey roundtrip across
+//     non-ASCII headwords (Gestirn, chien, …).
+//
+// CI integration: .github/workflows/release.yml runs this as a hard
+// gate before any release artifact is produced. If wikdict.com is
+// unreachable, the runner script fails the release deliberately —
+// we'd rather block a release than ship one without verifying real
+// upstream content still renders correctly.
+
+import {existsSync, readFileSync} from 'node:fs';
+import {join} from 'node:path';
+import {buildDict, lookupDict} from '../../src/core/dict/stardict/stardictDict';
+import {htmlToPlainText} from '../../src/ui/htmlToPlainText';
+import {MANIFEST} from './manifest';
+
+const RUN_INTEGRATION = process.env.SNDICT_INTEGRATION === '1';
+const CACHE_DIR = join(__dirname, '..', '..', '.cache', 'integration-dicts');
+
+const describeIntegration = RUN_INTEGRATION ? describe : describe.skip;
+
+describeIntegration('Real-StarDict regression (run via `npm run test:integration`)', () => {
+  for (const dict of MANIFEST) {
+    describe(`${dict.name} — ${dict.description}`, () => {
+      const dir = join(CACHE_DIR, dict.name);
+      const cacheReady = existsSync(join(dir, 'stardict.ifo'));
+
+      if (!cacheReady) {
+        // Intentional placeholder: when the runner downloaded the
+        // manifest but this specific entry's extract is missing
+        // (e.g. partial cleanup, hand-edited cache), surface a
+        // visibly-skipped test rather than silently dropping the
+        // dict's coverage. eslint-disable: no-disabled-tests warns
+        // on test.skip in general, but here it's deliberate
+        // defensive code, not forgotten WIP.
+        // eslint-disable-next-line jest/no-disabled-tests
+        test.skip(`${dict.name} not in cache — runner did not extract this dict`, () => {});
+        return;
+      }
+
+      // Resolved once per dict. The buildDict promise is awaited
+      // inside each test (jest-friendly) rather than in beforeAll,
+      // so a build failure in one dict doesn't mask other dicts'
+      // tests under a missing-fixture symptom.
+      let parsedPromise: ReturnType<typeof buildDict> | null = null;
+      const getParsed = (): ReturnType<typeof buildDict> => {
+        if (parsedPromise === null) {
+          // Locate the dict-data directory inside the extracted
+          // archive. WikDict zips contain a single top-level
+          // folder whose stardict.* files we read here. The
+          // runner script normalises this layout so we can rely
+          // on a stable shape.
+          const ifo = readFileSync(join(dir, 'stardict.ifo'));
+          const idx = readFileSync(join(dir, 'stardict.idx'));
+          const dictBytes = readFileSync(join(dir, 'stardict.dict.dz'));
+          parsedPromise = buildDict(
+            new Uint8Array(ifo),
+            new Uint8Array(idx),
+            new Uint8Array(dictBytes),
+          );
+        }
+        return parsedPromise;
+      };
+
+      for (const expectation of dict.entries) {
+        test(`lookup "${expectation.word}" renders without glue`, async () => {
+          const parsed = await getParsed();
+          const hit = lookupDict(parsed, expectation.word);
+          // Failure here means the dict's headword set changed.
+          // That's the signal to update the manifest, not to ship.
+          expect(hit).not.toBeNull();
+          if (!hit) {
+            return;
+          }
+          const rendered = htmlToPlainText(hit.definition);
+
+          for (const sub of expectation.contains) {
+            expect(rendered).toContain(sub);
+          }
+          for (const sub of expectation.notContains ?? []) {
+            // notContains is the bug-shape pin. A regression that
+            // re-glues translation onto definition text fires
+            // here with a clear "<dict> <word> contains
+            // <bad-string>" trace.
+            expect(rendered).not.toContain(sub);
+          }
+          for (const re of expectation.matches ?? []) {
+            expect(rendered).toMatch(re);
+          }
+          // Universal invariant: stripping should leave no HTML
+          // tag residue regardless of upstream shape.
+          expect(rendered).not.toMatch(/<\/?[a-z]/i);
+        });
+      }
+    });
+  }
+});

--- a/__tests__/jsonDictSource.test.ts
+++ b/__tests__/jsonDictSource.test.ts
@@ -1,4 +1,5 @@
 import {createJsonDictSource} from '../src/core/dict/jsonDictSource';
+import {YIELD_PERIOD} from '../src/core/dict/yieldOften';
 
 const enc = (s: string) => new TextEncoder().encode(s).buffer;
 
@@ -218,6 +219,62 @@ describe('createJsonDictSource', () => {
     const hit = await src.lookup('apple');
     expect(hit).toEqual({word: 'apple', definition: 'fruit', format: 'plain'});
     expect(hit).not.toHaveProperty('phonetic');
+  });
+
+  test('array shape: yields cooperatively over a large array (UI-blocking guard)', async () => {
+    const total = YIELD_PERIOD + 5;
+    const arr: Array<{word: string; definition: string}> = [];
+    for (let i = 0; i < total; i++) {
+      arr.push({word: `w${i}`, definition: `def${i}`});
+    }
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    try {
+      const src = fromJson(JSON.stringify(arr));
+      expect((await src.lookup('w0'))?.definition).toBe('def0');
+      expect((await src.lookup(`w${total - 1}`))?.definition).toBe(
+        `def${total - 1}`,
+      );
+      // Minimum yield budget for the array shape:
+      //   1 after decodeText
+      // + 1 after JSON.parse
+      // + ⌊total / YIELD_PERIOD⌋ during iteration
+      // = 3 for total = period + 5.
+      const zeroDelayCalls = setTimeoutSpy.mock.calls.filter(
+        c => c[1] === 0,
+      );
+      const expectedMin = 2 + Math.floor(total / YIELD_PERIOD);
+      expect(zeroDelayCalls.length).toBeGreaterThanOrEqual(expectedMin);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
+  });
+
+  test('object-map shape: yields cooperatively over a large map (UI-blocking guard)', async () => {
+    const obj: Record<string, string> = {};
+    const total = YIELD_PERIOD + 5;
+    for (let i = 0; i < total; i++) {
+      obj[`w${i}`] = `def${i}`;
+    }
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    try {
+      const src = fromJson(JSON.stringify(obj));
+      expect((await src.lookup('w0'))?.definition).toBe('def0');
+      // Minimum yield budget for the object-map shape:
+      //   1 after decodeText
+      // + 1 after JSON.parse
+      // + 1 after Object.keys (the only remaining non-yieldable
+      //   allocation — explicitly bounded so a regression that
+      //   drops it shows up here)
+      // + ⌊total / YIELD_PERIOD⌋ during iteration
+      // = 4 for total = period + 5.
+      const zeroDelayCalls = setTimeoutSpy.mock.calls.filter(
+        c => c[1] === 0,
+      );
+      const expectedMin = 3 + Math.floor(total / YIELD_PERIOD);
+      expect(zeroDelayCalls.length).toBeGreaterThanOrEqual(expectedMin);
+    } finally {
+      setTimeoutSpy.mockRestore();
+    }
   });
 
   test('lazy: loader fires once across many lookups', async () => {

--- a/__tests__/parseIdx.test.ts
+++ b/__tests__/parseIdx.test.ts
@@ -1,6 +1,6 @@
 import {parseIdx} from '../src/core/dict/stardict/parseIdx';
 import {buildSyntheticStarDict} from './_helpers/buildSyntheticStarDict';
-import {YIELD_PERIOD} from '../src/core/dict/stardict/yieldOften';
+import {YIELD_PERIOD} from '../src/core/dict/yieldOften';
 
 describe('parseIdx', () => {
   test('parses a synthetic 32-bit index back into ordered (word, offset, length)', async () => {

--- a/__tests__/parseSyn.test.ts
+++ b/__tests__/parseSyn.test.ts
@@ -1,5 +1,5 @@
 import {parseSyn} from '../src/core/dict/stardict/parseSyn';
-import {YIELD_PERIOD} from '../src/core/dict/stardict/yieldOften';
+import {YIELD_PERIOD} from '../src/core/dict/yieldOften';
 
 const enc = (s: string) => new TextEncoder().encode(s);
 

--- a/__tests__/userDictDiscovery.test.ts
+++ b/__tests__/userDictDiscovery.test.ts
@@ -126,11 +126,114 @@ describe('discoverUserDicts', () => {
     ).toMatch(/looks like StarDict — put it in a subfolder/);
   });
 
-  test('ignores meta.json at the root (only meaningful inside a folder)', async () => {
+  test('a lone meta.json at the root with no dict files yields nothing', async () => {
     const deps = baseDeps({
       [`${ROOT}/meta.json`]: enc(JSON.stringify({name: 'Stray'})),
     });
+    // No CSV/JSON to bind it to — meta.json alone is config, not a dict.
     expect(await discoverUserDicts(deps)).toEqual([]);
+  });
+
+  test('shared meta.json at root applies csv.phoneticCol to a flat-layout CSV (mavproductions/Dune issue)', async () => {
+    // Real-world layout from issue #2: user drops a CSV plus a single
+    // meta.json side by side at SnDict root, no subfolder. The third
+    // CSV column is a pronunciation, surfaced via meta.json. Before
+    // this wiring, phoneticCol was silently dropped at root level.
+    const deps = baseDeps({
+      [`${ROOT}/Dune.csv`]: enc(
+        'CALADAN,third planet of Delta Pavonis,KAL-ah-dan\n' +
+          'ARRAKIS,the planet known as Dune,uh-RAK-is\n',
+      ),
+      [`${ROOT}/meta.json`]: enc(JSON.stringify({csv: {phoneticCol: 2}})),
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(sources.length).toBe(1);
+    expect(sources[0].name).toBe('Dune');
+    const caladan = await sources[0].lookup('caladan');
+    expect(caladan?.phonetic).toBe('KAL-ah-dan');
+    expect(caladan?.definition).toBe('third planet of Delta Pavonis');
+    const arrakis = await sources[0].lookup('ARRAKIS');
+    expect(arrakis?.phonetic).toBe('uh-RAK-is');
+  });
+
+  test('shared root meta.json `name` is NOT broadcast to flat-layout files (would collide)', async () => {
+    // Shared meta would otherwise force two CSVs into the same display
+    // name. Only `csv.*` schema config is shared; `name` requires a
+    // per-file sidecar to apply.
+    const deps = baseDeps({
+      [`${ROOT}/Dune.csv`]: enc('ARRAKIS,the planet,uh-RAK-is\n'),
+      [`${ROOT}/medical.csv`]: enc('apple,fruit,AP-ul\n'),
+      [`${ROOT}/meta.json`]: enc(
+        JSON.stringify({name: 'Shared', csv: {phoneticCol: 2}}),
+      ),
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(sources.map(s => s.name).sort()).toEqual(['Dune', 'medical']);
+    // csv.phoneticCol still propagates to both.
+    expect((await sources[0].lookup('arrakis'))?.phonetic).toBe('uh-RAK-is');
+    expect((await sources[1].lookup('apple'))?.phonetic).toBe('AP-ul');
+  });
+
+  test('per-file `<base>.meta.json` sidecar overrides the shared root meta.json', async () => {
+    // Sidecar gives Dune.csv phoneticCol=2 + a custom display name;
+    // medical.csv has no sidecar so it inherits the shared meta's
+    // hasHeader=true.
+    const deps = baseDeps({
+      [`${ROOT}/Dune.csv`]: enc(
+        'CALADAN,third planet,KAL-ah-dan\nARRAKIS,Dune,uh-RAK-is\n',
+      ),
+      [`${ROOT}/Dune.meta.json`]: enc(
+        JSON.stringify({name: 'Dune (Frank Herbert)', csv: {phoneticCol: 2}}),
+      ),
+      [`${ROOT}/medical.csv`]: enc('term,definition\napple,fruit\n'),
+      [`${ROOT}/meta.json`]: enc(JSON.stringify({csv: {hasHeader: true}})),
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(sources.map(s => s.name)).toEqual(['Dune (Frank Herbert)', 'medical']);
+    const caladan = await sources[0].lookup('caladan');
+    expect(caladan?.phonetic).toBe('KAL-ah-dan');
+    // medical.csv used hasHeader=true from the shared meta, so the
+    // header row "term,definition" was skipped.
+    expect(await sources[1].lookup('term')).toBeNull();
+    expect((await sources[1].lookup('apple'))?.definition).toBe('fruit');
+  });
+
+  test('a `*.meta.json` sidecar is never itself treated as a JSON dict', async () => {
+    // Without isMetaJsonName guarding root-file detection, Dune.meta.json
+    // would be picked up as a JSON dict and confuse the popup.
+    const deps = baseDeps({
+      [`${ROOT}/Dune.csv`]: enc('A,definition,A-fonetik\n'),
+      [`${ROOT}/Dune.meta.json`]: enc(JSON.stringify({csv: {phoneticCol: 2}})),
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(sources.map(s => s.name)).toEqual(['Dune']);
+  });
+
+  test('shared root meta.json is not read at all when no flat-layout dict files exist', async () => {
+    // Subfolder dicts must not pick up the root meta as a sneak override
+    // — that meta belongs to flat-layout files only. Subfolder discovery
+    // continues to use its own per-folder meta.json.
+    const deps = baseDeps({
+      [`${ROOT}/meta.json`]: enc(JSON.stringify({csv: {phoneticCol: 99}})),
+      [`${ROOT}/sub/words.csv`]: enc('apple,fruit,A-pul\n'),
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(sources.length).toBe(1);
+    // phonetic is undefined: the subfolder dict didn't have its own
+    // meta.json, so phoneticCol stays at the default (none).
+    expect((await sources[0].lookup('apple'))?.phonetic).toBeUndefined();
+  });
+
+  test('per-file sidecar with malformed JSON falls back to defaults, dict still loads', async () => {
+    const deps = baseDeps({
+      [`${ROOT}/Dune.csv`]: enc('ARRAKIS,the planet,uh-RAK-is\n'),
+      [`${ROOT}/Dune.meta.json`]: enc('{not valid'),
+    });
+    const sources = await discoverUserDicts(deps);
+    expect(sources.length).toBe(1);
+    expect(sources[0].name).toBe('Dune');
+    // No phonetic since the sidecar couldn't be parsed.
+    expect((await sources[0].lookup('arrakis'))?.phonetic).toBeUndefined();
   });
 
   test('ignores unrecognised root files silently (e.g. README.md)', async () => {

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,25 @@ module.exports = {
   preset: 'react-native',
   passWithNoTests: true,
   // __tests__/_helpers/* are shared test utilities (not test suites).
-  testPathIgnorePatterns: ['/node_modules/', '/__tests__/_helpers/'],
+  // __tests__/integration/manifest.ts is the typed data manifest for
+  // the integration suite — a sibling to the test file, not a suite
+  // itself; jest's default testMatch glob ('__tests__/**') would
+  // otherwise try to load it as a (zero-test) suite and fail.
+  // The actual integration test file (wikdictRegression.test.ts) is
+  // NOT excluded — it gates on SNDICT_INTEGRATION=1 internally and
+  // describe.skip's when the var is missing, so `npm test` runs it
+  // in ~ms (all skipped).
+  testPathIgnorePatterns: [
+    '/node_modules/',
+    '/__tests__/_helpers/',
+    '/__tests__/integration/manifest\\.ts$',
+  ],
+  // Integration tests exercise the full StarDict→htmlToPlainText
+  // pipeline against real downloaded dicts (run only via
+  // `npm run test:integration`). They are an end-to-end gate, not a
+  // coverage source — exclude from coverage measurement so they
+  // can't skew the unit-test gate either way.
+  coveragePathIgnorePatterns: ['/__tests__/integration/'],
   collectCoverageFrom: [
     'src/**/*.{ts,tsx}',
     // Pure-types files have no executable code; istanbul reports

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint .",
     "start": "react-native start",
     "test": "jest",
+    "test:integration": "node scripts/runIntegrationTests.mjs",
     "coverage": "jest --coverage",
     "fetch:dict": "node scripts/fetchBaseDict.mjs",
     "build:dict": "node scripts/buildBaseDict.mjs",

--- a/scripts/runIntegrationTests.mjs
+++ b/scripts/runIntegrationTests.mjs
@@ -1,0 +1,249 @@
+#!/usr/bin/env node
+// Real-StarDict regression runner.
+//
+// Pipeline:
+//   1. Read the manifest (__tests__/integration/manifest.ts) by
+//      requiring it via tsx-style at-runtime parsing. Avoid: we
+//      duplicate the manifest's URL+SHA list here as a small
+//      JS-only mirror to skip the TS dep at runtime. Source of
+//      truth stays in manifest.ts; this mirror is checked at
+//      startup and fails loudly on drift.
+//   2. For each manifest dict:
+//      - Skip if cache hit (sha matches existing zip).
+//      - Otherwise download, sha-verify, extract into a stable
+//        layout: .cache/integration-dicts/<name>/stardict.{ifo,idx,dict.dz}.
+//   3. Spawn jest with SNDICT_INTEGRATION=1 and a path filter that
+//      runs only the integration suite. Inherit stdio so jest's
+//      output is the user's output.
+//   4. On clean exit, by default DELETE the .cache/integration-dicts/
+//      tree so a developer running locally doesn't accumulate ~12 MB
+//      of zips after one run. Pass --keep to retain (useful when
+//      iterating on assertions).
+//
+// Failure semantics: any of "manifest drift", "download fails",
+// "sha mismatch", "zip lacks expected layout", or "jest exits
+// non-zero" exits this script non-zero. The release workflow runs
+// this as a gate, so a non-zero exit blocks the release.
+
+import {spawn} from 'node:child_process';
+import {createHash} from 'node:crypto';
+import {createWriteStream, existsSync, mkdirSync, readFileSync, rmSync} from 'node:fs';
+import {dirname, join} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..');
+const CACHE_DIR = join(REPO_ROOT, '.cache', 'integration-dicts');
+
+// Mirror of __tests__/integration/manifest.ts. Kept JS-only so this
+// script doesn't need ts-node. Drift between the two is checked at
+// startup: we read manifest.ts as text and grep the SHA pins.
+const MANIFEST_MIRROR = [
+  {
+    name: 'wikdict-de-fr',
+    url: 'https://download.wikdict.com/dictionaries/stardict/wikdict-de-fr.zip',
+    sha256: '17d00ca43cd6e80089c66dd2959aff30535a355ba36c4d39d6537c0948d37c41',
+  },
+  {
+    name: 'wikdict-fr-de',
+    url: 'https://download.wikdict.com/dictionaries/stardict/wikdict-fr-de.zip',
+    sha256: '95f73aff4271c5eaf68d5c426b8fd1bc728880ead0e63b9e8cc84b9e934b3f68',
+  },
+  {
+    name: 'wikdict-de-en',
+    url: 'https://download.wikdict.com/dictionaries/stardict/wikdict-de-en.zip',
+    sha256: 'e84d6ec7a5e92f2232fe9c1fe04f149dd0b4defab47b879705d1a395138f5024',
+  },
+];
+
+const args = new Set(process.argv.slice(2));
+const KEEP_CACHE = args.has('--keep');
+
+const log = (msg) => console.log(`[integration] ${msg}`);
+const fail = (msg) => {
+  console.error(`[integration] ✗ ${msg}`);
+  process.exit(1);
+};
+
+// Mirror-vs-source drift check. If someone updates manifest.ts but
+// not this script (or vice-versa), surface it now rather than after
+// downloads complete with the wrong content.
+const verifyManifestDrift = () => {
+  const manifestPath = join(REPO_ROOT, '__tests__', 'integration', 'manifest.ts');
+  const text = readFileSync(manifestPath, 'utf-8');
+  for (const {name, sha256} of MANIFEST_MIRROR) {
+    if (!text.includes(name)) {
+      fail(`manifest.ts missing entry for "${name}" (mirror drift in scripts/runIntegrationTests.mjs)`);
+    }
+    if (!text.includes(sha256)) {
+      fail(`manifest.ts SHA pin for "${name}" doesn't match runner mirror — update one to match the other`);
+    }
+  }
+};
+
+const sha256Of = (path) => {
+  const h = createHash('sha256');
+  h.update(readFileSync(path));
+  return h.digest('hex');
+};
+
+const downloadTo = async (url, dest) => {
+  log(`downloading ${url}`);
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`fetch ${url} -> HTTP ${res.status}`);
+  }
+  if (!res.body) {
+    throw new Error(`fetch ${url} returned an empty body`);
+  }
+  await new Promise((resolve, reject) => {
+    const out = createWriteStream(dest);
+    out.on('finish', resolve);
+    out.on('error', reject);
+    // Web Streams reader → Node writable.
+    const reader = res.body.getReader();
+    const pump = async () => {
+      while (true) {
+        const {value, done} = await reader.read();
+        if (done) break;
+        if (!out.write(value)) {
+          await new Promise((r) => out.once('drain', r));
+        }
+      }
+      out.end();
+    };
+    pump().catch(reject);
+  });
+};
+
+// Extract a single-top-level-folder zip into <destDir>/ such that the
+// stardict.* files end up directly under destDir. We use the system
+// `unzip` because it's available on every CI runner we care about
+// (ubuntu-latest, macOS-latest) and pulling in a node zip lib for
+// one consumer would be overkill.
+const extractZip = (zipPath, destDir) => {
+  return new Promise((resolve, reject) => {
+    // -j flag: junk paths (flatten); writes all files into destDir
+    // regardless of how deep they were nested in the zip. Wikdict
+    // wraps everything in one folder, so flattening lands us with
+    // stardict.ifo / stardict.idx / stardict.dict.dz directly under
+    // destDir — exactly what the test expects.
+    const child = spawn('unzip', ['-q', '-o', '-j', zipPath, '-d', destDir], {
+      stdio: 'inherit',
+    });
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`unzip exited with code ${code}`));
+      }
+    });
+    child.on('error', reject);
+  });
+};
+
+const ensureDictReady = async ({name, url, sha256}) => {
+  const dictDir = join(CACHE_DIR, name);
+  const zipPath = join(CACHE_DIR, `${name}.zip`);
+  const stardictIfo = join(dictDir, 'stardict.ifo');
+
+  // Hot path: already extracted AND archive matches the SHA pin.
+  if (existsSync(stardictIfo) && existsSync(zipPath)) {
+    if (sha256Of(zipPath) === sha256) {
+      log(`${name} cache hit (sha verified)`);
+      return;
+    }
+    log(`${name} cache mismatch — re-downloading`);
+  }
+
+  mkdirSync(dictDir, {recursive: true});
+  await downloadTo(url, zipPath);
+
+  const actual = sha256Of(zipPath);
+  if (actual !== sha256) {
+    fail(
+      `${name} SHA mismatch:\n  expected ${sha256}\n  actual   ${actual}\n` +
+        `Either upstream rebuilt the dict (update manifest.ts pin), or the download\n` +
+        `was corrupted in transit. Re-run after investigating.`,
+    );
+  }
+  await extractZip(zipPath, dictDir);
+  if (!existsSync(stardictIfo)) {
+    fail(
+      `${name} extract did not produce stardict.ifo at ${dictDir}.\n` +
+        `Check the zip's internal layout — the runner expects a single\n` +
+        `top-level folder with stardict.{ifo,idx,dict.dz}.`,
+    );
+  }
+  log(`${name} ready`);
+};
+
+const runJest = () =>
+  new Promise((resolve, reject) => {
+    const child = spawn(
+      'npx',
+      [
+        'jest',
+        '--testPathPattern',
+        '__tests__/integration/',
+        '--passWithNoTests',
+      ],
+      {
+        cwd: REPO_ROOT,
+        stdio: 'inherit',
+        env: {...process.env, SNDICT_INTEGRATION: '1'},
+      },
+    );
+    child.on('exit', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`jest exited with code ${code}`));
+      }
+    });
+    child.on('error', reject);
+  });
+
+const cleanup = () => {
+  if (KEEP_CACHE) {
+    log(`keeping cache at ${CACHE_DIR} (--keep specified)`);
+    return;
+  }
+  if (existsSync(CACHE_DIR)) {
+    rmSync(CACHE_DIR, {recursive: true, force: true});
+    log(`cache cleaned`);
+  }
+};
+
+const main = async () => {
+  verifyManifestDrift();
+  mkdirSync(CACHE_DIR, {recursive: true});
+
+  for (const dict of MANIFEST_MIRROR) {
+    try {
+      await ensureDictReady(dict);
+    } catch (e) {
+      fail(`${dict.name}: ${e.message}`);
+    }
+  }
+
+  // Run jest. Cleanup runs regardless of jest's exit code so we don't
+  // leave zips behind on CI if a test fails.
+  let jestError = null;
+  try {
+    await runJest();
+  } catch (e) {
+    jestError = e;
+  }
+  cleanup();
+  if (jestError) {
+    fail(jestError.message);
+  }
+  log('all integration tests passed');
+};
+
+main().catch((e) => {
+  console.error(e);
+  cleanup();
+  process.exit(1);
+});

--- a/src/core/dict/csvDictSource.ts
+++ b/src/core/dict/csvDictSource.ts
@@ -7,11 +7,19 @@
 //
 // Lookup is case-insensitive. First occurrence of a key wins (later
 // duplicates are ignored), matching StarDict's behaviour.
+//
+// Async + cooperative-yield: a multi-MB CSV (10 MB cap below) means
+// ~100k row iterations. On Hermes the JS thread runs everything;
+// without yielding, parse blocks input on the e-ink overlay for the
+// duration. We yield to the event loop every YIELD_PERIOD rows so
+// the popup ("Loading…") can paint and tap input stays live during
+// first-load priming.
 
 import {decodeText} from '../../sdk/textDecode';
 import type {DictEntry, DictSource} from '../lookup';
 import {createLazyAsyncSource} from './lazyAsyncSource';
 import {normalizeKey} from './normalizeKey';
+import {shouldYield, yieldToEventLoop} from './yieldOften';
 
 export type LoadBytes = () => Promise<ArrayBuffer | null>;
 
@@ -112,8 +120,15 @@ const buildCsv = (
     Pick<CsvDictDeps, 'headwordCol' | 'definitionCol' | 'hasHeader'>
   > & {phoneticCol: number | undefined},
 ) =>
-  (bytes: Uint8Array): ParsedCsv => {
+  async (bytes: Uint8Array): Promise<ParsedCsv> => {
+    // decodeText runs the native TextDecoder over the full buffer in
+    // one synchronous chunk — fast (~tens of ms even at 10 MB) but
+    // still non-yieldable. A yield here bounds the worst-case
+    // pre-iteration pause, so anything queued on the JS thread
+    // (popup paint, "Loading…" placeholder) gets to land before we
+    // start the row loop.
     const text = decodeText(bytes);
+    await yieldToEventLoop();
     const index = new Map<string, CsvRow>();
     let cursor = 0;
     let rowIdx = 0;
@@ -127,19 +142,23 @@ const buildCsv = (
       rowIdx++;
       const word = next.row[deps.headwordCol]?.trim() ?? '';
       const definition = next.row[deps.definitionCol] ?? '';
-      if (word.length === 0) {
-        continue;
-      }
-      const key = normalizeKey(word);
-      if (key.length > 0 && !index.has(key)) {
-        const row: CsvRow = {word, definition};
-        if (deps.phoneticCol !== undefined) {
-          const phonetic = next.row[deps.phoneticCol]?.trim() ?? '';
-          if (phonetic.length > 0) {
-            row.phonetic = phonetic;
+      if (word.length > 0) {
+        const key = normalizeKey(word);
+        if (key.length > 0 && !index.has(key)) {
+          const row: CsvRow = {word, definition};
+          if (deps.phoneticCol !== undefined) {
+            const phonetic = next.row[deps.phoneticCol]?.trim() ?? '';
+            if (phonetic.length > 0) {
+              row.phonetic = phonetic;
+            }
           }
+          index.set(key, row);
         }
-        index.set(key, row);
+      }
+      // Yield based on rows *seen* (rowIdx), not entries kept, so a
+      // file full of skipped/duplicate rows still yields on schedule.
+      if (shouldYield(rowIdx)) {
+        await yieldToEventLoop();
       }
     }
     return {index};

--- a/src/core/dict/jsonDictSource.ts
+++ b/src/core/dict/jsonDictSource.ts
@@ -6,12 +6,19 @@
 //      so users don't have to be precise about field names)
 //
 // Lookup is case-insensitive. First occurrence of a key wins.
+//
+// Async + cooperative-yield: native JSON.parse runs in C++ and is
+// fast even for MB-scale files, but the JS-side iteration that
+// builds the lookup map is exactly the kind of long synchronous
+// loop that freezes input on Hermes. We yield every YIELD_PERIOD
+// entries — same discipline as CSV and StarDict.
 
 import {decodeText} from '../../sdk/textDecode';
 import type {DictEntry, DictSource} from '../lookup';
 import {createLazyAsyncSource} from './lazyAsyncSource';
 import type {LoadBytes} from './csvDictSource';
 import {normalizeKey} from './normalizeKey';
+import {shouldYield, yieldToEventLoop} from './yieldOften';
 
 export type JsonDictDeps = {
   name: string;
@@ -71,9 +78,20 @@ const pickPhonetic = (row: Record<string, unknown>): string | undefined => {
 const isPlainObject = (v: unknown): v is Record<string, unknown> =>
   typeof v === 'object' && v !== null && !Array.isArray(v);
 
-const buildJson = (bytes: Uint8Array): ParsedJson => {
+const buildJson = async (bytes: Uint8Array): Promise<ParsedJson> => {
+  // Three pre-iteration yields close every non-yieldable boundary in
+  // this parser: decodeText (native TextDecoder), JSON.parse (native
+  // C++ parse), and the single allocation that materialises the key
+  // list before iteration starts. Each step is fast (tens of ms even
+  // at 10 MB), but back-to-back without any yield between them they
+  // can stack into a perceptible pause — and they sit BEFORE the
+  // iteration's own yield gate, so the per-iteration discipline can't
+  // recover the time. Yielding at every transition lets the popup
+  // paint a "Loading…" placeholder and keeps tap input live.
   const text = decodeText(bytes);
+  await yieldToEventLoop();
   const data: unknown = JSON.parse(text);
+  await yieldToEventLoop();
   const index = new Map<string, JsonRow>();
 
   const insert = (word: string, definition: string, phonetic?: string): void => {
@@ -91,22 +109,42 @@ const buildJson = (bytes: Uint8Array): ParsedJson => {
     }
   };
 
+  // Yield convention: every loop in this codebase yields on the
+  // *count of iterations completed*, not the loop index. So
+  // shouldYield(i + 1) here matches CSV's `shouldYield(rowIdx)` and
+  // parseIdx's `shouldYield(entries.length)` — first yield fires
+  // after exactly YIELD_PERIOD entries processed, regardless of
+  // which loop you're in.
   if (Array.isArray(data)) {
-    for (const row of data) {
-      if (!isPlainObject(row)) {
-        continue;
+    for (let i = 0; i < data.length; i++) {
+      const row = data[i];
+      if (isPlainObject(row)) {
+        const w = pickHeadword(row);
+        const d = pickDefinition(row);
+        const p = pickPhonetic(row);
+        if (typeof w === 'string' && typeof d === 'string') {
+          insert(w, d, p);
+        }
       }
-      const w = pickHeadword(row);
-      const d = pickDefinition(row);
-      const p = pickPhonetic(row);
-      if (typeof w === 'string' && typeof d === 'string') {
-        insert(w, d, p);
+      if (shouldYield(i + 1)) {
+        await yieldToEventLoop();
       }
     }
   } else if (isPlainObject(data)) {
-    for (const [w, d] of Object.entries(data)) {
+    // Object.keys is one allocation of length N (string refs only),
+    // ~3x lighter than Object.entries which builds N two-element
+    // tuples. Yield right after so the only synchronous chunk in
+    // this branch is the keys allocation itself.
+    const keys = Object.keys(data);
+    await yieldToEventLoop();
+    for (let i = 0; i < keys.length; i++) {
+      const w = keys[i];
+      const d = data[w];
       if (typeof d === 'string') {
         insert(w, d);
+      }
+      if (shouldYield(i + 1)) {
+        await yieldToEventLoop();
       }
     }
   } else {

--- a/src/core/dict/stardict/parseIdx.ts
+++ b/src/core/dict/stardict/parseIdx.ts
@@ -14,7 +14,7 @@
 // the UI.
 
 import {decodeUtf8} from '../../../sdk/utf8';
-import {shouldYield, yieldToEventLoop} from './yieldOften';
+import {shouldYield, yieldToEventLoop} from '../yieldOften';
 
 export type IdxEntry = {
   word: string;

--- a/src/core/dict/stardict/parseSyn.ts
+++ b/src/core/dict/stardict/parseSyn.ts
@@ -17,7 +17,7 @@
 // hundreds of thousands of entries. Same yield discipline as parseIdx.
 
 import {decodeUtf8} from '../../../sdk/utf8';
-import {shouldYield, yieldToEventLoop} from './yieldOften';
+import {shouldYield, yieldToEventLoop} from '../yieldOften';
 
 export type SynEntry = {
   word: string;

--- a/src/core/dict/stardict/stardictDict.ts
+++ b/src/core/dict/stardict/stardictDict.ts
@@ -22,7 +22,7 @@ import type {DictReader} from './dictReader';
 import {createDictReader} from './dictReader';
 import {decodeUtf8} from '../../../sdk/utf8';
 import {normalizeKey} from '../normalizeKey';
-import {shouldYield, yieldToEventLoop} from './yieldOften';
+import {shouldYield, yieldToEventLoop} from '../yieldOften';
 
 export type ParsedDict = {
   meta: IfoMeta;

--- a/src/core/dict/userDictDiscovery.ts
+++ b/src/core/dict/userDictDiscovery.ts
@@ -1,10 +1,12 @@
 // Scans the user-dict root (defaults to /storage/emulated/0/MyStyle/SnDict)
 // and returns a DictSource for every recognised dictionary folder.
 // Each DictSource is lazy — discovery only inspects file metadata
-// and (optionally) reads each folder's small `meta.json`. Heavy
+// and (optionally) reads each dict's small `meta.json`. Heavy
 // parsing happens on first lookup against that source.
 //
-// Folder layout, per dict:
+// Two layouts are supported. Both can coexist in the same root.
+//
+// Organised layout (one dict per subfolder):
 //
 //   <SnDict-root>/<name>/
 //     ├── meta.json                      (optional)
@@ -12,6 +14,19 @@
 //     ├── *.csv                          -> CSV
 //     ├── *.json                         -> JSON
 //     └── *.mdx                          -> logged as deferred (skipped)
+//
+// Flat layout (single-file dicts at the root):
+//
+//   <SnDict-root>/
+//     ├── meta.json                      (optional, applies to ALL flat-
+//     │                                   layout files unless overridden)
+//     ├── Dune.csv                       -> CSV
+//     ├── Dune.meta.json                 (optional sidecar; overrides
+//     │                                   the shared meta.json for Dune.csv)
+//     └── medical.json                   -> JSON
+//
+// StarDict has multiple required files and never qualifies for flat
+// layout. CSV/JSON each stand on their own.
 //
 // meta.json schema (all fields optional):
 //
@@ -25,8 +40,8 @@
 //     }
 //   }
 //
-// Per-folder failures are isolated and logged — one bad dict folder
-// doesn't break discovery for the others.
+// Per-folder/per-file failures are isolated and logged — one bad
+// dict doesn't break discovery for the others.
 
 import {decodeUtf8} from '../../sdk/utf8';
 import type {DictSource} from '../lookup';
@@ -105,6 +120,13 @@ const basenameOf = (path: string): string => {
   return slash >= 0 ? path.slice(slash + 1) : path;
 };
 
+// `meta.json` is the shared/folder convention; `<basename>.meta.json`
+// is the per-file sidecar convention at root level. Both must be
+// excluded from JSON-dict detection so the meta config never gets
+// mistaken for an actual dictionary file.
+const isMetaJsonName = (name: string): boolean =>
+  name === 'meta.json' || name.toLowerCase().endsWith('.meta.json');
+
 type CsvMetaConfig = {
   headwordCol?: number;
   definitionCol?: number;
@@ -158,14 +180,10 @@ const parseCsvMeta = (raw: unknown): CsvMetaConfig | undefined => {
   return cfg;
 };
 
-const readFolderMeta = async (
-  files: FileEntry[],
+const readMetaFile = async (
+  meta: FileEntry,
   fetchFn: typeof fetch,
 ): Promise<FolderMeta> => {
-  const meta = files.find(f => f.type === 1 && basenameOf(f.path) === 'meta.json');
-  if (!meta) {
-    return {};
-  }
   try {
     const text = decodeUtf8(await fetchAsUint8(meta.path, fetchFn));
     const parsed: unknown = JSON.parse(text);
@@ -184,6 +202,14 @@ const readFolderMeta = async (
   } catch {
     return {};
   }
+};
+
+const readFolderMeta = async (
+  files: FileEntry[],
+  fetchFn: typeof fetch,
+): Promise<FolderMeta> => {
+  const meta = files.find(f => f.type === 1 && basenameOf(f.path) === 'meta.json');
+  return meta ? await readMetaFile(meta, fetchFn) : {};
 };
 
 type DetectedFormat =
@@ -213,9 +239,10 @@ const detectFormat = (files: FileEntry[]): DetectedFormat => {
   );
   const syn = filesOnly.find(f => extOf(f.path) === '.syn');
   const csv = filesOnly.find(f => extOf(f.path) === '.csv');
-  // Exclude meta.json from JSON dict candidates.
+  // Exclude meta.json (and any *.meta.json sidecar) from JSON dict
+  // candidates — these are config, not dictionary content.
   const json = filesOnly.find(
-    f => extOf(f.path) === '.json' && basenameOf(f.path) !== 'meta.json',
+    f => extOf(f.path) === '.json' && !isMetaJsonName(basenameOf(f.path)),
   );
   const mdx = filesOnly.find(f => extOf(f.path) === '.mdx');
 
@@ -358,26 +385,54 @@ const nameFromFile = (filePath: string): string => {
   return dot < 0 ? base : base.slice(0, dot);
 };
 
+// Locate a per-file meta sidecar — `<base>.meta.json` next to the
+// dict file. Lets users disambiguate when multiple CSVs share the
+// root with different schemas (e.g. Dune.csv + Dune.meta.json,
+// medical.csv + medical.meta.json). Sidecars take precedence over
+// the shared root meta.json.
+const findSidecarMeta = (
+  file: FileEntry,
+  rootFiles: FileEntry[],
+): FileEntry | undefined => {
+  const display = nameFromFile(file.path);
+  const target = `${display}.meta.json`;
+  return rootFiles.find(
+    f => f.type === 1 && basenameOf(f.path) === target,
+  );
+};
+
 // Build a source for a single dict file living directly in the root
 // (no surrounding folder). StarDict is multi-file and never qualifies
 // here — it must be in a subfolder. CSV and JSON are single-file and
 // stand on their own. MDX is logged as deferred.
+//
+// `meta` carries the resolved config for this specific file (sidecar
+// override, or fall-back to the shared root meta.json). For CSV that
+// includes phoneticCol — a third column users overwhelmingly want
+// surfaced as pronunciation in the popup header but which discovery
+// previously had no way of binding to a flat-layout file. JSON has no
+// configurable schema, so meta only contributes the display name.
 const buildSourceForRootFile = (
   file: FileEntry,
   fetchFn: typeof fetch,
   logger: Logger,
+  meta: FolderMeta,
 ): DictSource | null => {
   const ext = extOf(file.path);
   const baseName = basenameOf(file.path);
-  const displayName = nameFromFile(file.path);
+  const displayName = meta.name ?? nameFromFile(file.path);
   if (ext === '.csv') {
     return createCsvDictSource({
       name: displayName,
       loadBytes: () => fetchAsArrayBuffer(file.path, fetchFn),
+      headwordCol: meta.csv?.headwordCol,
+      definitionCol: meta.csv?.definitionCol,
+      phoneticCol: meta.csv?.phoneticCol,
+      hasHeader: meta.csv?.hasHeader,
       logger,
     });
   }
-  if (ext === '.json' && baseName !== 'meta.json') {
+  if (ext === '.json' && !isMetaJsonName(baseName)) {
     return createJsonDictSource({
       name: displayName,
       loadBytes: () => fetchAsArrayBuffer(file.path, fetchFn),
@@ -444,9 +499,42 @@ export const discoverUserDicts = async (
   // Root-level files (flat layout): each .csv / .json IS a complete
   // dict on its own — no subfolder wrapper needed. StarDict triples
   // can't live here; they require a subfolder.
+  //
+  // Two opt-in sources of per-file config exist at root level:
+  //   1. `<basename>.meta.json` sidecar — wins if present, scoped to
+  //      that one dict file.
+  //   2. shared `meta.json` at root — applies as the fallback to every
+  //      root-level dict that has no sidecar. Matches the simplest
+  //      single-file layout (one CSV + one meta.json next to it),
+  //      which is what most users reach for first.
+  //
+  // Skip the read entirely when there's no chance the caller cares —
+  // i.e. when the only root file types are unrelated (.txt, .md, etc).
+  const hasRootDictFile = rootFiles.some(f => {
+    const ext = extOf(f.path);
+    if (ext === '.csv') {
+      return true;
+    }
+    if (ext === '.json' && !isMetaJsonName(basenameOf(f.path))) {
+      return true;
+    }
+    return false;
+  });
+  const sharedRootMeta: FolderMeta = hasRootDictFile
+    ? await readFolderMeta(rootFiles, fetchFn)
+    : {};
+
   for (const file of rootFiles) {
     try {
-      const source = buildSourceForRootFile(file, fetchFn, logger);
+      const sidecar = findSidecarMeta(file, rootFiles);
+      // Sidecar meta is scoped to one file, so its `name` is safe to
+      // honour. Shared root meta is broadcast to every flat-layout
+      // dict — its `name` would collide if there's more than one, so
+      // we strip it and only carry the schema config across.
+      const fileMeta: FolderMeta = sidecar
+        ? await readMetaFile(sidecar, fetchFn)
+        : {csv: sharedRootMeta.csv};
+      const source = buildSourceForRootFile(file, fetchFn, logger, fileMeta);
       if (source !== null) {
         sources.push(source);
       }

--- a/src/core/dict/yieldOften.ts
+++ b/src/core/dict/yieldOften.ts
@@ -1,9 +1,10 @@
-// Cooperative-yield helper for long synchronous loops (StarDict
-// `.idx` parsing, `.syn` parsing, the index-build pass over hundreds
-// of thousands of entries). Hermes runs every loop on the JS thread,
-// so a multi-second loop blocks UI input — the visible "5-minute
-// freeze on first lookup" symptom users hit with large user-supplied
-// dictionaries.
+// Cooperative-yield helper for long synchronous loops. Used by every
+// dict format (StarDict `.idx` / `.syn` / index-build, CSV row parse,
+// JSON array-of-entries iteration) — anywhere a multi-MB user file
+// would otherwise spin the JS thread for several seconds. Hermes runs
+// every loop on the JS thread, so without yielding the visible
+// symptom is "freezing/locking input" the moment the user taps to
+// look up a word and triggers first-load of a large dictionary.
 //
 // Yielding via a macrotask (setTimeout 0) — not a microtask — gives
 // the JS thread room to drain pending UI events and spinners between

--- a/src/ui/htmlToPlainText.ts
+++ b/src/ui/htmlToPlainText.ts
@@ -79,14 +79,59 @@ export const htmlToPlainText = (html: string): string => {
       const name = tagNameOf(html.slice(i + 1, end));
       // Layout substitutions for the structural tags Wiktionary-style
       // dicts use. Other tags (i, b, span, font, …) drop, content stays.
+      const isClose = html.slice(i + 1, end).trim().startsWith('/');
       if (name === 'br') {
         out += '\n';
-      } else if (name === 'li' && !html.slice(i + 1, end).trim().startsWith('/')) {
+      } else if (name === 'li' && !isClose) {
         // Opening <li>: introduce a bullet on its own line.
         out += '\n• ';
-      } else if (name === 'p' && !html.slice(i + 1, end).trim().startsWith('/')) {
+      } else if (name === 'p' && !isClose) {
         // Opening <p>: paragraph break.
         out += '\n\n';
+      } else if (name === 'div') {
+        // <div> is Wikdict's wrapper for translation lines AND the
+        // outer container for the whole entry. Treat it as a soft
+        // block boundary so `...sichtbar ist<div>astre</div>` no
+        // longer renders as the glued `istastre` (issue #15).
+        //
+        // Rule: insert a newline on open <div> unless we're already
+        // at the start of a line (or of the entry). Determining that
+        // means looking past any trailing inline whitespace at the
+        // last meaningful character:
+        //   - empty output       → at start of entry, skip (no leading blank)
+        //   - last non-space '\n' → at line start, skip
+        //   - last non-space '•' → inside an <li> bullet ("\n• "),
+        //                          skip so the bullet keeps its content
+        //   - anything else      → inside text content, INSERT '\n'
+        //                          (covers both the no-trailing-space
+        //                          Gestirn case and the trailing-space
+        //                          variant `…ist <div>astre</div>`,
+        //                          where space alone is not enough to
+        //                          un-glue the translation).
+        //
+        // Closing </div> always emits '\n' so adjacent <div> siblings
+        // in <ol>/<li> structures separate cleanly; the post-pass
+        // collapses any \n{2,} so this never produces double-blanks.
+        if (isClose) {
+          out += '\n';
+        } else {
+          // Walk back past any inline whitespace — including NBSP
+          // (U+00A0), which decodeEntity emits for `&nbsp;`. A
+          // future Wikdict shape with `…ist&nbsp;<div>astre</div>`
+          // would otherwise be treated as "still inside text" and
+          // glue translation onto the line. Treating NBSP as
+          // whitespace here keeps the discriminator robust.
+          let j = out.length - 1;
+          while (
+            j >= 0 &&
+            (out[j] === ' ' || out[j] === '\t' || out[j] === ' ')
+          ) {
+            j--;
+          }
+          if (j >= 0 && out[j] !== '\n' && out[j] !== '•') {
+            out += '\n';
+          }
+        }
       }
       // /li, /ol, /ul, ol, ul, /p, and all unknown tags: no output.
       i = end + 1;


### PR DESCRIPTION
## Summary

- **fix(parsers)** — closes every freeze hazard in the CSV/JSON parse paths by routing both through cooperative-yield loops (`yieldOften`) so multi-MB user dicts no longer block the JS thread on first lookup. `yieldOften` lifted out of `stardict/` since CSV and JSON now share it.
- **fix(html)** — `htmlToPlainText` treats `<div>` as a soft block boundary so Wikdict-shape entries like `…sichtbar ist<div>astre</div>` render as `…sichtbar ist\nastre` instead of the glued `istastre`. Release-gated real-StarDict regression suite added (de-fr, fr-de, de-en, SHA-pinned) as a hard CI gate.
- **fix(discovery)** — flat-layout dicts (`MyStyle/SnDict/Dune.csv` + sibling `meta.json`) now actually consume `meta.json`. Both forms supported: a shared `meta.json` at root (broadcasts only `csv.*` schema, never `name`), and a per-file `<basename>.meta.json` sidecar (wins, scopes both `name` and `csv.*` to one file). `*.meta.json` is excluded from JSON-dict detection so sidecars are never themselves treated as dicts.
- README expanded with WikDict + xxyzz/wiktionary_stardict + per-language pointers for direct non-English pairs (de-fr, fr-de, la-fr, …).

## Issues

- Closes #15 — Wikdict translation glue (`istastre`)
- Closes #16 — non-English dict sources documentation
- Re #2 — phonetic on root-layout CSV (mavproductions thread); this PR fixes the discovery side. Issue stays open as the feature thread.
- Re #14 — investigated, not a rendering bug (Wikdict StarDict export omits inflection upstream; wikdict.com adds it via a separate Wiktionary call). Will be closed on the issue with that finding.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 556 unit passing across 34 suites
- [x] `npm run coverage` — 99.3% statements / 97.36% branches / 99.29% lines (above the 97% bar)
- [x] `npm run test:integration` — release-gated; 5 real-StarDict end-to-end checks against SHA-pinned Wikdict zips
- [x] Real-file verification of root-layout phonetic against `Dune_with_Phonetics.csv`: `lookup('ABA').phonetic === 'AH-bah'`, `lookup("muad'dib").phonetic === 'mwah-DEEB'`
- [ ] On-device smoke test of the rel8 build by mavproductions (root `Dune.csv` + `meta.json {"csv":{"phoneticCol":2}}`)
- [ ] On-device smoke test of the rel8 build by alioth9 (Wikdict de-fr `Gestirn` no longer renders as `…ist astre` glued)