### PR TITLE
fix(html): numbered nested lists + bold translations (issue #19) + release workflow knobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,23 @@
 name: Release
 
-# Manually-triggered release. The `version` input is optional:
-#   - Leave blank to auto-bump the latest `v*` tag by patch
-#     (e.g. v0.1.0 -> v0.1.1). If no tag exists yet, the first release
-#     is v0.1.0.
-#   - Or type a specific MAJOR.MINOR.PATCH (with or without leading `v`).
+# Manually-triggered release. Inputs:
+#   version     — optional. Leave blank to auto-bump the latest `v*`
+#                 tag by patch (e.g. v0.1.0 -> v0.1.1). If no tag
+#                 exists yet, the first release is v0.1.0. Or type a
+#                 specific MAJOR.MINOR.PATCH (with or without `v`).
+#   prerelease  — when true, publishes the GitHub Release flagged as
+#                 a pre-release (the "Pre-release" badge appears on
+#                 the release page). Useful for shipping `-rc` /
+#                 testing builds without affecting users on stable.
+#                 Defaults to false. Independent of the version
+#                 string — we don't enforce a `-rc` suffix here.
+#   make_latest — when true, GitHub marks this release as the
+#                 repo's "Latest" release. Set false when shipping a
+#                 hot-patch on an older line, or any pre-release
+#                 you don't want to surface as the headline
+#                 download. Defaults to true. GitHub also auto-
+#                 demotes pre-releases from "Latest" regardless,
+#                 but pinning it explicitly is clearer.
 #
 # The workflow:
 #   1. Runs lint + tests as gates.
@@ -15,7 +28,8 @@ name: Release
 #      creates an annotated `vX.Y.Z` tag, pushes both.
 #   6. Generates release notes (changes + contributors, excluding
 #      GitHub Copilot and the github-actions release bot itself).
-#   7. Publishes a GitHub Release with the notes and the .snplg.
+#   7. Publishes a GitHub Release with the notes and the .snplg,
+#      respecting the `prerelease` / `make_latest` flags.
 
 on:
   workflow_dispatch:
@@ -24,6 +38,16 @@ on:
         description: 'Release version (e.g. 0.1.1). Leave blank to auto-bump patch from the latest v* tag. First release is v0.1.0.'
         required: false
         default: ''
+      prerelease:
+        description: 'Mark this release as a pre-release on GitHub.'
+        type: boolean
+        required: false
+        default: false
+      make_latest:
+        description: 'Mark this release as "Latest" on the repo. Uncheck to publish without bumping the Latest badge (e.g. hot-patches or pre-releases).'
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   contents: write
@@ -223,3 +247,9 @@ jobs:
           name: ${{ steps.ver.outputs.tag }}
           body: ${{ steps.notes.outputs.notes }}
           files: build/outputs/SnDict.snplg
+          # workflow_dispatch boolean inputs surface as the strings
+          # "true" / "false". The action accepts a boolean for
+          # `prerelease` and one of "true" / "false" / "legacy" for
+          # `make_latest`, so passing the raw string for both works.
+          prerelease: ${{ github.event.inputs.prerelease }}
+          make_latest: ${{ github.event.inputs.make_latest }}

--- a/__tests__/DefinitionPopup.test.tsx
+++ b/__tests__/DefinitionPopup.test.tsx
@@ -398,7 +398,7 @@ describe('DefinitionPopup', () => {
     // Tags stripped, layout preserved as bullet/newline.
     expect(text).not.toMatch(/<\/?[a-z]/i);
     expect(text).toContain('intj');
-    expect(text).toContain('• A salutation');
+    expect(text).toContain('1. A salutation');
   });
 
   test('format=plain: definition renders verbatim (no parser, no strip)', () => {

--- a/__tests__/HtmlText.test.tsx
+++ b/__tests__/HtmlText.test.tsx
@@ -1,0 +1,176 @@
+// Render-tree assertions for the HtmlText component.
+//
+// Two things to verify:
+//   1. The visible text concatenation matches what htmlToPlainText
+//      / htmlToSpans produce (so the popup never displays a
+//      different string than the plain-text fallback would).
+//   2. Style props on nested <Text> elements honour bold / italic /
+//      colour for content spans, and layout chunks (newlines, list
+//      markers, em-dashes) render unstyled.
+
+jest.mock('react-native', () => ({
+  Text: 'Text',
+  StyleSheet: {create: (s: unknown) => s},
+}));
+
+import React from 'react';
+import {act, create, type ReactTestRenderer} from 'react-test-renderer';
+import {HtmlText} from '../src/ui/HtmlText';
+import {htmlToPlainText} from '../src/ui/htmlToPlainText';
+
+type RTNode = {
+  type: string;
+  props: Record<string, unknown>;
+  children: Array<RTNode | string> | null;
+};
+
+const render = (html: string, style?: object): ReactTestRenderer => {
+  let tree!: ReactTestRenderer;
+  act(() => {
+    tree = create(<HtmlText html={html} style={style} />);
+  });
+  return tree;
+};
+
+const flatten = (node: RTNode | string | null): string => {
+  if (node === null) {
+    return '';
+  }
+  if (typeof node === 'string') {
+    return node;
+  }
+  if (!node.children) {
+    return '';
+  }
+  return node.children.map(flatten).join('');
+};
+
+const collectAllNodes = (root: RTNode): RTNode[] => {
+  const out: RTNode[] = [root];
+  if (root.children) {
+    for (const child of root.children) {
+      if (typeof child !== 'string' && child) {
+        out.push(...collectAllNodes(child));
+      }
+    }
+  }
+  return out;
+};
+
+describe('HtmlText', () => {
+  test('renders empty string as a single empty <Text>', () => {
+    const tree = render('');
+    const root = tree.toJSON() as unknown as RTNode;
+    expect(root.type).toBe('Text');
+  });
+
+  test('visible text matches htmlToPlainText for the same input', () => {
+    const html =
+      '<div><font color="green">noun, male</font><br><ol>' +
+      '<li>Haustier, dessen Vorfahre der Wolf ist<ol>' +
+      '<li><div>chien</div></li>' +
+      '<li><div>chienne</div></li>' +
+      '</ol></li></ol></div>';
+    const tree = render(html);
+    const root = tree.toJSON() as unknown as RTNode;
+    expect(flatten(root)).toBe(htmlToPlainText(html));
+  });
+
+  test('forwards the style prop to the root <Text>', () => {
+    const baseStyle = {fontSize: 17, lineHeight: 24, color: '#000'};
+    const tree = render('plain', baseStyle);
+    const root = tree.toJSON() as unknown as RTNode;
+    expect(root.props.style).toEqual(baseStyle);
+  });
+
+  test('emboldens the inline-translation <div> content via fontWeight 700', () => {
+    const tree = render(
+      '<ol><li>Astronomie: der Kosmos<div>ciel</div></li></ol>',
+    );
+    const root = tree.toJSON() as unknown as RTNode;
+    const all = collectAllNodes(root);
+    // Find the Text whose ONLY child is "ciel".
+    const cielText = all.find(
+      (n) =>
+        n.type === 'Text' &&
+        n.children?.length === 1 &&
+        n.children[0] === 'ciel',
+    );
+    expect(cielText).toBeDefined();
+    const style = cielText?.props.style as {fontWeight?: string} | undefined;
+    expect(style?.fontWeight).toBe('700');
+  });
+
+  test('italicises <i> content (POS labels) and does not italicise surrounding text', () => {
+    const tree = render('a <i>POS</i> b');
+    const root = tree.toJSON() as unknown as RTNode;
+    const all = collectAllNodes(root);
+    const posText = all.find(
+      (n) =>
+        n.type === 'Text' &&
+        n.children?.length === 1 &&
+        n.children[0] === 'POS',
+    );
+    expect(posText).toBeDefined();
+    expect(
+      (posText?.props.style as {fontStyle?: string} | undefined)?.fontStyle,
+    ).toBe('italic');
+    // The surrounding "a " / " b" text is unwrapped strings (no
+    // dedicated <Text>), so they appear as direct children of the
+    // root Text.
+    expect(root.children).toContain('a ');
+    expect(root.children).toContain(' b');
+  });
+
+  test('applies <font color> to the wrapped content only', () => {
+    const tree = render('<font color="green">noun</font> body');
+    const root = tree.toJSON() as unknown as RTNode;
+    const all = collectAllNodes(root);
+    const colored = all.find(
+      (n) =>
+        n.type === 'Text' &&
+        n.children?.length === 1 &&
+        n.children[0] === 'noun',
+    );
+    expect(
+      (colored?.props.style as {color?: string} | undefined)?.color,
+    ).toBe('green');
+    // ' body' is unstyled — appears as a raw string child.
+    expect(root.children).toContain(' body');
+  });
+
+  test('list markers render as raw strings (not wrapped in styled <Text>)', () => {
+    // The marker "1. " should not be inside any styled inner <Text>;
+    // even when the list lives inside a <font color> scope, the
+    // marker stays plain. Otherwise nested numbering picks up colour
+    // and looks visually broken on e-ink.
+    const tree = render(
+      '<font color="green"><ol><li>foo</li></ol></font>',
+    );
+    const root = tree.toJSON() as unknown as RTNode;
+    const all = collectAllNodes(root);
+    // No styled Text contains "1." in its own subtree.
+    for (const node of all) {
+      if (
+        node !== root &&
+        node.type === 'Text' &&
+        node.props.style !== undefined
+      ) {
+        const innerText = flatten(node);
+        expect(innerText).not.toContain('1.');
+      }
+    }
+  });
+
+  test('memoises the parse: identical html prop reuses children', () => {
+    // Re-rendering with the same html must not re-parse. We assert
+    // this by rendering, snapshotting, re-rendering with the same
+    // html, and comparing — any cache miss would still produce the
+    // same output, but this also serves as a stability pin.
+    const html =
+      '<ol><li>x<div>y</div></li><li>a<div>b</div></li></ol>';
+    const t1 = render(html);
+    const t2 = render(html);
+    expect(t1.toJSON()).toEqual(t2.toJSON());
+  });
+});

--- a/__tests__/end-to-end.test.tsx
+++ b/__tests__/end-to-end.test.tsx
@@ -219,7 +219,7 @@ describe('end-to-end (discovery → registry → popup)', () => {
     const text = collectText(tree);
     expect(text).not.toMatch(/<\/?[a-z]/i);
     expect(text).toContain('intj');
-    expect(text).toContain('• greeting');
+    expect(text).toContain('1. greeting');
   });
 
   test('mid-flight discovery prepend does not break in-flight lookups (regression)', async () => {

--- a/__tests__/htmlParser.test.ts
+++ b/__tests__/htmlParser.test.ts
@@ -1,0 +1,235 @@
+// Direct tests for the shared HTML tokenizer. Most of its behaviour
+// is exercised through htmlToPlainText / htmlToSpans, but a few
+// parser-level edge cases (attribute quoting, malformed tags,
+// entity decoding boundaries) are clearer to pin at this layer.
+
+import {parseHtml, looksLikeHtml, type TagInfo} from '../src/ui/htmlParser';
+
+type Event =
+  | {kind: 'text'; value: string}
+  | {kind: 'tag'; tag: TagInfo};
+
+const collect = (html: string): Event[] => {
+  const events: Event[] = [];
+  parseHtml(html, {
+    onText: (value) => events.push({kind: 'text', value}),
+    onTag: (tag) => events.push({kind: 'tag', tag}),
+  });
+  return events;
+};
+
+describe('looksLikeHtml', () => {
+  test('detects opening tags', () => {
+    expect(looksLikeHtml('<i>hi</i>')).toBe(true);
+  });
+
+  test('detects self-closing tags', () => {
+    expect(looksLikeHtml('hi<br/>there')).toBe(true);
+  });
+
+  test('detects close tags only', () => {
+    expect(looksLikeHtml('hi</i>')).toBe(true);
+  });
+
+  test('rejects plain text', () => {
+    expect(looksLikeHtml('a greeting used for most purposes')).toBe(false);
+  });
+
+  test('rejects text with stray angle brackets (no tag-like name)', () => {
+    expect(looksLikeHtml('x < y')).toBe(false);
+  });
+});
+
+describe('parseHtml — empty + fast path', () => {
+  test('empty string emits nothing', () => {
+    expect(collect('')).toEqual([]);
+  });
+
+  test('plain text without entities or tags emits a single text event', () => {
+    expect(collect('hello world')).toEqual([
+      {kind: 'text', value: 'hello world'},
+    ]);
+  });
+});
+
+describe('parseHtml — tag events', () => {
+  test('open tag emits {isClose: false}', () => {
+    expect(collect('<b>')).toEqual([
+      {kind: 'tag', tag: {name: 'b', isClose: false, attrs: {}}},
+    ]);
+  });
+
+  test('close tag emits {isClose: true}', () => {
+    expect(collect('</b>')).toEqual([
+      {kind: 'tag', tag: {name: 'b', isClose: true, attrs: {}}},
+    ]);
+  });
+
+  test('self-closing tag emits a single open event (no close)', () => {
+    // Consumer-side note: <br/> only emits open. Tags whose semantic
+    // close is a no-op (br, hr, img) should be handled by ignoring
+    // close events for those names; this parser never invents one.
+    expect(collect('<br/>')).toEqual([
+      {kind: 'tag', tag: {name: 'br', isClose: false, attrs: {}}},
+    ]);
+  });
+
+  test('lowercases tag names', () => {
+    expect(collect('<DIV><Br></DIV>')).toEqual([
+      {kind: 'tag', tag: {name: 'div', isClose: false, attrs: {}}},
+      {kind: 'tag', tag: {name: 'br', isClose: false, attrs: {}}},
+      {kind: 'tag', tag: {name: 'div', isClose: true, attrs: {}}},
+    ]);
+  });
+});
+
+describe('parseHtml — attribute parsing', () => {
+  test('double-quoted attribute value', () => {
+    expect(collect('<font color="green">')).toEqual([
+      {
+        kind: 'tag',
+        tag: {name: 'font', isClose: false, attrs: {color: 'green'}},
+      },
+    ]);
+  });
+
+  test('single-quoted attribute value', () => {
+    expect(collect("<font color='red'>")).toEqual([
+      {
+        kind: 'tag',
+        tag: {name: 'font', isClose: false, attrs: {color: 'red'}},
+      },
+    ]);
+  });
+
+  test('unquoted attribute value', () => {
+    expect(collect('<font color=blue>')).toEqual([
+      {
+        kind: 'tag',
+        tag: {name: 'font', isClose: false, attrs: {color: 'blue'}},
+      },
+    ]);
+  });
+
+  test('multiple attributes on one tag', () => {
+    expect(collect('<a href="https://x" title="t">')).toEqual([
+      {
+        kind: 'tag',
+        tag: {
+          name: 'a',
+          isClose: false,
+          attrs: {href: 'https://x', title: 't'},
+        },
+      },
+    ]);
+  });
+
+  test('valueless boolean-style attribute records empty string', () => {
+    expect(collect('<input disabled>')).toEqual([
+      {
+        kind: 'tag',
+        tag: {name: 'input', isClose: false, attrs: {disabled: ''}},
+      },
+    ]);
+  });
+
+  test('attribute names lowercase', () => {
+    expect(collect('<font Color="green">')).toEqual([
+      {
+        kind: 'tag',
+        tag: {name: 'font', isClose: false, attrs: {color: 'green'}},
+      },
+    ]);
+  });
+
+  test('whitespace around = is tolerated', () => {
+    expect(collect('<font color = "green">')).toEqual([
+      {
+        kind: 'tag',
+        tag: {name: 'font', isClose: false, attrs: {color: 'green'}},
+      },
+    ]);
+  });
+
+  test('self-closing slash does not become an attribute', () => {
+    expect(collect('<br />')).toEqual([
+      {kind: 'tag', tag: {name: 'br', isClose: false, attrs: {}}},
+    ]);
+  });
+});
+
+describe('parseHtml — entity decoding', () => {
+  test('named entities decode to characters', () => {
+    expect(collect('a&amp;b&nbsp;c')).toEqual([
+      // NBSP (U+00A0) is what &nbsp; decodes to.
+      {kind: 'text', value: 'a&b\u00a0c'},
+    ]);
+  });
+
+  test('numeric decimal entity', () => {
+    expect(collect('&#65;')).toEqual([{kind: 'text', value: 'A'}]);
+  });
+
+  test('numeric hex entity (lowercase x)', () => {
+    expect(collect('&#x41;')).toEqual([{kind: 'text', value: 'A'}]);
+  });
+
+  test('numeric hex entity (uppercase X)', () => {
+    expect(collect('&#X41;')).toEqual([{kind: 'text', value: 'A'}]);
+  });
+
+  test('out-of-range numeric entity emits nothing', () => {
+    expect(collect('&#999999999;')).toEqual([]);
+  });
+
+  test('zero numeric entity emits nothing (codepoint 0 is rejected)', () => {
+    expect(collect('&#0;')).toEqual([]);
+  });
+
+  test('unknown named entity emits nothing for the entity itself', () => {
+    expect(collect('a&totallymadeup;b')).toEqual([{kind: 'text', value: 'ab'}]);
+  });
+
+  test('& with no semicolon within 20 chars is literal', () => {
+    expect(collect('use & for and')).toEqual([
+      {kind: 'text', value: 'use & for and'},
+    ]);
+  });
+
+  test('empty entity (&;) emits nothing for the entity', () => {
+    expect(collect('a&;b')).toEqual([{kind: 'text', value: 'ab'}]);
+  });
+});
+
+describe('parseHtml — malformed input', () => {
+  test('unclosed tag at end-of-input surfaces as literal text', () => {
+    // The fast path doesn't fire (input has '<' that does NOT match
+    // a well-formed tag pattern). The slow path's no-> branch
+    // captures the suffix as text.
+    expect(collect('<b>good</b> tail <unclosed extra')).toEqual([
+      {kind: 'tag', tag: {name: 'b', isClose: false, attrs: {}}},
+      {kind: 'text', value: 'good'},
+      {kind: 'tag', tag: {name: 'b', isClose: true, attrs: {}}},
+      // Adjacent text events are NOT merged by the parser; the
+      // pre-tag flush emits this slice on its own.
+      {kind: 'text', value: ' tail <unclosed extra'},
+    ]);
+  });
+
+  test('input that starts with < but has no closing > is literal text', () => {
+    // Fast path: looksLikeHtml is false (no well-formed-looking
+    // tag), no '&' either, so the parser emits the whole input as
+    // a single text event without scanning.
+    expect(collect('a <unclosed b c')).toEqual([
+      {kind: 'text', value: 'a <unclosed b c'},
+    ]);
+  });
+
+  test('UTF-8 / multi-byte content inside tags survives', () => {
+    expect(collect('<i>नमस्ते</i>')).toEqual([
+      {kind: 'tag', tag: {name: 'i', isClose: false, attrs: {}}},
+      {kind: 'text', value: 'नमस्ते'},
+      {kind: 'tag', tag: {name: 'i', isClose: true, attrs: {}}},
+    ]);
+  });
+});

--- a/__tests__/htmlToPlainText.test.ts
+++ b/__tests__/htmlToPlainText.test.ts
@@ -35,9 +35,32 @@ describe('htmlToPlainText', () => {
     expect(htmlToPlainText('a<br>b<br/>c<br />d')).toBe('a\nb\nc\nd');
   });
 
-  test('converts <li> to bulleted line', () => {
+  test('numbers <ol> items with "N. " markers (v1.0.9)', () => {
     expect(htmlToPlainText('<ol><li>first</li><li>second</li></ol>')).toBe(
+      '1. first\n2. second',
+    );
+  });
+
+  test('keeps "• " bullets for <ul> items', () => {
+    expect(htmlToPlainText('<ul><li>first</li><li>second</li></ul>')).toBe(
       '• first\n• second',
+    );
+  });
+
+  test('indents nested <ol> items by 2 spaces per nesting level', () => {
+    const html =
+      '<ol><li>outer one<ol><li>inner a</li><li>inner b</li></ol></li>' +
+      '<li>outer two</li></ol>';
+    expect(htmlToPlainText(html)).toBe(
+      '1. outer one\n  1. inner a\n  2. inner b\n2. outer two',
+    );
+  });
+
+  test('mixed <ol> + <ul> nest each maintain their own marker style', () => {
+    const html =
+      '<ol><li>numbered<ul><li>bullet a</li><li>bullet b</li></ul></li></ol>';
+    expect(htmlToPlainText(html)).toBe(
+      '1. numbered\n  • bullet a\n  • bullet b',
     );
   });
 
@@ -49,10 +72,12 @@ describe('htmlToPlainText', () => {
       'namaste</li></ol>';
     const out = htmlToPlainText(html);
     expect(out).toContain('intj');
-    expect(out).toContain('• A salutation; a greeting used for most purposes');
+    expect(out).toContain('1. A salutation; a greeting used for most purposes');
     expect(out).toContain('noun');
+    // Nested under an outer <ol> opened just before <i>noun</i>: the
+    // inner <ol>'s items show at depth 2 (two-space indent).
     expect(out).toContain(
-      '• greeting, salutation, an instance of the interjection namaste',
+      '  1. greeting, salutation, an instance of the interjection namaste',
     );
     // No tags leak through.
     expect(out).not.toMatch(/<\/?[a-z]/i);
@@ -63,7 +88,7 @@ describe('htmlToPlainText', () => {
     expect(htmlToPlainText('1 &lt; 2 &gt; 0')).toBe('1 < 2 > 0');
     expect(htmlToPlainText('&quot;hi&quot;')).toBe('"hi"');
     expect(htmlToPlainText('it&apos;s')).toBe("it's");
-    expect(htmlToPlainText('a&nbsp;b')).toBe('a b');
+    expect(htmlToPlainText('a&nbsp;b')).toBe('a\u00a0b');
   });
 
   test('decodes numeric HTML entities (decimal and hex)', () => {
@@ -75,7 +100,7 @@ describe('htmlToPlainText', () => {
   test('drops unknown / malformed entities cleanly', () => {
     // Unknown name -> empty string.
     expect(htmlToPlainText('a &totallymadeup; b')).toBe('a b');
-    // No semicolon within 10 chars -> treat & as literal.
+    // No semicolon within 20 chars -> treat & as literal.
     expect(htmlToPlainText('use & for and')).toBe('use & for and');
   });
 
@@ -139,13 +164,19 @@ describe('htmlToPlainText', () => {
     expect(htmlToPlainText(plain)).toBe(plain);
   });
 
-  describe('Wikdict <div>-translation shape (issue #15)', () => {
+  describe('Wikdict <div>-translation shape (issues #15 + #19)', () => {
     // Verbatim definition extracted from wikdict-de-fr.zip's
     // stardict.dict for headword "Gestirn" (offset 5002035, len 222).
     // Wikdict wraps each translation in <div>...</div> directly after
-    // the German definition text, with no <br> or other separator —
-    // so v1.0.6's renderer concatenated "ist" and "astre" into
-    // "istastre". This test pins the fix.
+    // the German definition text, with no <br> or other separator.
+    //
+    //   - Pre-v1.0.7 the renderer concatenated "ist" and "astre" into
+    //     "istastre" (issue #15).
+    //   - v1.0.8 split them onto two lines (`ist\nastre`).
+    //   - v1.0.9 joins them inline with an em-dash separator
+    //     (`ist — astre`) per alioth9's follow-up on issue #15: "I
+    //     think it would be better to have the translation on the
+    //     same line and rather have some separator like em-dash".
     const wikdictGestirn =
       '<div>/<font color="gray">ɡəˈʃtɪʁn</font>/<br>\n' +
       '<font color="green">noun, neutral</font><br>' +
@@ -153,12 +184,15 @@ describe('htmlToPlainText', () => {
       'Allgemeinen, welcher am Nachthimmel sichtbar ist' +
       '<div>astre</div></div>';
 
-    test('does not glue definition text to the following <div> translation', () => {
+    test('joins definition text and translation with " — " separator', () => {
       const out = htmlToPlainText(wikdictGestirn);
       // The smoking-gun regression: "istastre" must not appear.
       expect(out).not.toMatch(/istastre/);
-      // Translation appears separated from the definition body.
-      expect(out).toMatch(/sichtbar ist\s*\n+\s*astre/);
+      // Translation joins inline with em-dash, not a newline.
+      expect(out).toMatch(/sichtbar ist — astre/);
+      // And explicitly NOT the v1.0.8 newline shape — pin the format
+      // so a future revert can't quietly regress.
+      expect(out).not.toMatch(/sichtbar ist\nastre/);
     });
 
     test('preserves all upstream content (IPA, POS, definition, translation)', () => {
@@ -173,51 +207,43 @@ describe('htmlToPlainText', () => {
 
     test('outer <div> wrapper does not produce a leading blank line', () => {
       // The whole entry is wrapped in <div>...</div>; the open tag
-      // sits at position 0 with no prior content. The renderer must
-      // not emit a leading newline that would make the popup look
-      // like it had an empty first line.
+      // sits at position 0 with no prior content. Inline-vs-block
+      // discrimination must pick block-mode here so the popup
+      // doesn't render a leading empty first line.
       const out = htmlToPlainText(wikdictGestirn);
       expect(out.startsWith('\n')).toBe(false);
     });
 
-    test('trailing &nbsp; before <div> still un-glues translation (NBSP variant)', () => {
-      // Belt-and-suspenders for the trailing-space heuristic. A
-      // future upstream shape with `&nbsp;` (decoded to U+00A0)
-      // immediately before <div>...</div> would, with a naive
-      // "skip space and tab only" walkback, still be treated as
-      // mid-text and gain a newline — but only because the NBSP
-      // itself isn't whitespace to that walker. The discriminator
-      // explicitly includes U+00A0 so the result is identical to
-      // the regular-space case.
+    test('NBSP before <div> still triggers the inline em-dash join', () => {
+      // Belt-and-suspenders: a future Wikdict shape with `&nbsp;`
+      // (decoded to U+00A0) immediately before <div>...</div> should
+      // still pass the "content on this line → inline em-dash" test.
+      // The contentOnLine tracker treats NBSP as whitespace so the
+      // last meaningful char (the body word) wins.
       const nbspBeforeDiv =
         '<div>Definition body&nbsp;<div>translation</div></div>';
       const out = htmlToPlainText(nbspBeforeDiv);
-      expect(out).toMatch(/Definition body\s*\n+\s*translation/);
+      expect(out).toMatch(/Definition body — translation/);
       expect(out).not.toMatch(/body translation/);
     });
 
-    test('trailing-space-before-<div> variant still un-glues translation (e.g. "…ist <div>astre</div>")', () => {
-      // Defensive: a future Wikdict export might emit a trailing
-      // space between the definition text and the translation block.
-      // The naive "skip newline if last char is whitespace" rule
-      // would still glue these as `…ist astre` (joined with just a
-      // space). The implementation looks past trailing spaces at the
-      // last meaningful character, so the newline still fires.
+    test('trailing-space-before-<div> still triggers em-dash join', () => {
+      // Defensive: `…ist <div>astre</div>` (trailing single space
+      // between definition and translation) collapses through the
+      // post-pass — the em-dash separator is what un-glues them.
       const trailingSpace =
         '<div>Astronomie: Himmelskörper, welcher am Nachthimmel sichtbar ist ' +
         '<div>astre</div></div>';
       const out = htmlToPlainText(trailingSpace);
-      // Translation appears on a fresh line, not glued behind a
-      // single space.
-      expect(out).toMatch(/sichtbar ist\s*\n+\s*astre/);
+      expect(out).toMatch(/sichtbar ist — astre/);
       expect(out).not.toMatch(/ist astre/);
     });
 
-    test('multi-translation entries (Wikdict <ol><li><div>...</div></li>) keep bullets and break translations onto their own lines', () => {
-      // Real-world shape from wikdict-de-fr "Hund": two translations
-      // under the same sense, each in <li><div>...</div></li>. The
-      // bullet must survive (• chien on its own line) AND the bullets
-      // must not glue to surrounding text.
+    test('multi-translation Wikdict <ol><li><div>...</div></li> shape numbers items and bullets are gone', () => {
+      // Real shape from wikdict-de-fr "Hund": two translations under
+      // a nested <ol>. Each translation is the only content of its
+      // <li>, so each renders as a numbered item without an em-dash
+      // (block-mode div, line-start at the marker).
       const wikdictHund =
         '<div><font color="green">noun, male</font><br><ol>' +
         '<li>Haustier, dessen Vorfahre der Wolf ist<ol>' +
@@ -225,10 +251,87 @@ describe('htmlToPlainText', () => {
         '<li><div>chienne</div></li>' +
         '</ol></li></ol></div>';
       const out = htmlToPlainText(wikdictHund);
-      expect(out).toContain('• chien');
-      expect(out).toContain('• chienne');
-      // Bullets are on separate lines (not "• chien• chienne").
-      expect(out).toMatch(/• chien\s*\n\s*• chienne/);
+      // Outer <li> still gets its number; inner <li>s get nested
+      // depth-2 numbering.
+      expect(out).toMatch(/^noun, male/);
+      expect(out).toContain('1. Haustier, dessen Vorfahre der Wolf ist');
+      expect(out).toContain('  1. chien');
+      expect(out).toContain('  2. chienne');
+      // Pre-v1.0.7 glue: "istchien" must never appear.
+      expect(out).not.toMatch(/istchien/);
+      // Nested numbered items on consecutive lines (no blank gap
+      // between them after post-pass).
+      expect(out).toMatch(/ {2}1\. chien\n {2}2\. chienne/);
+    });
+
+    test('Himmel-style: <li>body<div>translation</div></li> joins inline', () => {
+      // The exact "Astronomie: der Kosmos<div>ciel</div>" shape from
+      // issue #19: the <div> follows real text WITHIN the same <li>,
+      // so it should join with an em-dash producing
+      // "2. Astronomie: der Kosmos — ciel" (depending on the outer
+      // numbering at the time of render).
+      const html =
+        '<ol><li>Astronomie: der Kosmos<div>ciel</div></li></ol>';
+      expect(htmlToPlainText(html)).toBe('1. Astronomie: der Kosmos — ciel');
+    });
+
+    test('multiple sibling <div> translations in one <li> join with comma', () => {
+      // alioth9's ideal in issue #19: "Decke aus Stoff oder ähnlichem
+      // Material — ciel, dais". Comma-join is the sibling-translation
+      // shape; this test pins it.
+      const html =
+        '<ol><li>Decke aus Stoff oder ähnlichem Material' +
+        '<div>ciel</div><div>dais</div></li></ol>';
+      expect(htmlToPlainText(html)).toBe(
+        '1. Decke aus Stoff oder ähnlichem Material — ciel, dais',
+      );
+    });
+
+    test('outer <li> with only a nested <ol> renders the outer marker on its own line', () => {
+      // Known-imperfect rendering for the Himmel shape where the
+      // outer <li> wraps two siblings <ol>s with no direct text.
+      // alioth9 acknowledged this is a file-level structural issue
+      // and even OSS-Dict can't pair them. We pin the simple "marker
+      // on its own line" output so behaviour is at least predictable.
+      const html =
+        '<ol>' +
+        '<li><ol><li>inner one</li><li>inner two</li></ol></li>' +
+        '<li>second top<div>tr</div></li>' +
+        '</ol>';
+      const out = htmlToPlainText(html);
+      expect(out).toContain('1.');
+      expect(out).toContain('  1. inner one');
+      expect(out).toContain('  2. inner two');
+      expect(out).toContain('2. second top — tr');
+    });
+  });
+
+  describe('inline-div translation edge cases', () => {
+    test('em-dash never doubles up: a sole <div> at the start renders block-mode', () => {
+      // The outer wrapper case: `<div>x</div>` has no preceding
+      // content, so block-mode selects and we don't emit a leading
+      // " — ".
+      expect(htmlToPlainText('<div>x</div>')).toBe('x');
+    });
+
+    test('three sibling translations: " — a, b, c"', () => {
+      // Stress the comma-list path past two siblings.
+      const html =
+        '<ol><li>body<div>a</div><div>b</div><div>c</div></li></ol>';
+      expect(htmlToPlainText(html)).toBe('1. body — a, b, c');
+    });
+
+    test('<br> between translations resets the comma-list state', () => {
+      // After a <br>, we're on a new line; even if a <div> follows
+      // some text, it's a fresh em-dash group, not a continuation
+      // of the previous <div> run.
+      const html = '<ol><li>a<div>x</div><br>b<div>y</div></li></ol>';
+      expect(htmlToPlainText(html)).toBe('1. a — x\nb — y');
+    });
+
+    test('paragraph-mode <p>x</p><p>y</p> preserves paragraph break', () => {
+      // <p> intent is two newlines collapsed to one by post-pass.
+      expect(htmlToPlainText('<p>x</p><p>y</p>')).toBe('x\ny');
     });
   });
 });

--- a/__tests__/htmlToPlainText.test.ts
+++ b/__tests__/htmlToPlainText.test.ts
@@ -306,6 +306,100 @@ describe('htmlToPlainText', () => {
     });
   });
 
+  describe('issue #19 verbatim Himmel HTML (wikdict-de-fr)', () => {
+    // Exact .dict-section HTML alioth9 pasted into issue #19 for
+    // headword "Himmel". Pinned verbatim (whitespace-formatted with
+    // the same tabs and newlines the upstream emits) so any future
+    // change to the renderer's whitespace handling shows up against
+    // the source-of-truth shape rather than a hand-massaged variant.
+    const himmelHtml =
+      '<div>/<font color="gray">ˈhɪml̩</font>/<br>\n' +
+      '<font color="green">noun, male</font><br>\n' +
+      '  <ol>\n' +
+      '\t<li>\n' +
+      '\t  <ol>\n' +
+      '\t\t<li>Luftraum, Gewölbe über der Erde</li>\n' +
+      '\t\t<li>Religion: Aufenthaltsort im Jenseits mit Gott und den ' +
+      'Engeln, in den die Seligen nach ihrem Tode aufgenommen werden</li>\n' +
+      '\t  </ol>\n' +
+      '\t  <ol>\n' +
+      '\t\t<li><div>ciel</div></li>\n' +
+      '\t\t<li><div>paradis</div></li>\n' +
+      '\t  </ol>\n' +
+      '\t</li>\n' +
+      '\t<li>Astronomie: der Kosmos<div>ciel</div></li>\n' +
+      '\t<li>Decke aus Stoff oder ähnlichem Material\n' +
+      '\t  <ol><li><div>ciel</div></li>\n' +
+      '\t\t<li><div>dais</div></li>\n' +
+      '\t  </ol></li>\n' +
+      '  </ol>\n' +
+      '</div>';
+
+    test('chrome (IPA + POS) appears once in order, no leading blank', () => {
+      const out = htmlToPlainText(himmelHtml);
+      expect(out.startsWith('\n')).toBe(false);
+      // IPA on its own line, POS on the next.
+      expect(out).toMatch(/^\/ˈhɪml̩\/\nnoun, male\n/);
+    });
+
+    test('top-level senses are numbered 1./2./3. and inner items indent at depth 2', () => {
+      const out = htmlToPlainText(himmelHtml);
+      // alioth9 acknowledged the file structurally puts the two
+      // sibling inner <ol>s under one outer <li>, so the outer
+      // "1." appears on its own line — even OSS-Dict can't pair
+      // them. We pin that predictable shape rather than fight it.
+      expect(out).toContain('1.');
+      // Sense 1 inner items (German definitions).
+      expect(out).toContain('  1. Luftraum, Gewölbe über der Erde');
+      expect(out).toContain(
+        '  2. Religion: Aufenthaltsort im Jenseits mit Gott und den Engeln',
+      );
+      // Sense 1 inner translations (still as their own depth-2 list).
+      expect(out).toContain('  1. ciel');
+      expect(out).toContain('  2. paradis');
+      // Sense 2: body + inline em-dash translation in one line.
+      expect(out).toContain('2. Astronomie: der Kosmos — ciel');
+      // Sense 3: body line, then nested numbered translations.
+      expect(out).toContain('3. Decke aus Stoff oder ähnlichem Material');
+      expect(out).toMatch(/3\. Decke[^\n]*\n {2}1\. ciel\n {2}2\. dais/);
+    });
+
+    test('does not emit any v1.0.6 / v1.0.8 glue regressions', () => {
+      const out = htmlToPlainText(himmelHtml);
+      // Pre-v1.0.7 glue forms.
+      expect(out).not.toMatch(/Erdeciel/);
+      expect(out).not.toMatch(/Materialciel/);
+      expect(out).not.toMatch(/Kosmosciel/);
+      // v1.0.8 newline-only shape that v1.0.9 replaces with em-dash
+      // for the inline translation case.
+      expect(out).not.toMatch(/Kosmos\nciel/);
+      // No HTML residue.
+      expect(out).not.toMatch(/<\/?[a-z]/i);
+    });
+
+    test('full snapshot of the rendered Himmel entry', () => {
+      // The full deterministic shape, as the popup body would
+      // display it. If a future change shifts whitespace or
+      // numbering, this assertion fails with a one-character diff.
+      // Update intentionally only in lockstep with a UX decision.
+      expect(htmlToPlainText(himmelHtml)).toBe(
+        [
+          '/ˈhɪml̩/',
+          'noun, male',
+          '1.',
+          '  1. Luftraum, Gewölbe über der Erde',
+          '  2. Religion: Aufenthaltsort im Jenseits mit Gott und den Engeln, in den die Seligen nach ihrem Tode aufgenommen werden',
+          '  1. ciel',
+          '  2. paradis',
+          '2. Astronomie: der Kosmos — ciel',
+          '3. Decke aus Stoff oder ähnlichem Material',
+          '  1. ciel',
+          '  2. dais',
+        ].join('\n'),
+      );
+    });
+  });
+
   describe('inline-div translation edge cases', () => {
     test('em-dash never doubles up: a sole <div> at the start renders block-mode', () => {
       // The outer wrapper case: `<div>x</div>` has no preceding

--- a/__tests__/htmlToSpans.test.ts
+++ b/__tests__/htmlToSpans.test.ts
@@ -241,6 +241,81 @@ describe('htmlToSpans — full Wikdict + Wiktionary entry shape', () => {
       'green',
     );
   });
+
+  test('Himmel (issue #19 verbatim wikdict-de-fr HTML) renders with proper styling', () => {
+    // Verbatim HTML alioth9 pasted into issue #19. Pinned here at
+    // the span level so the bold / colour / numbering decisions
+    // for this exact upstream shape can't drift without a test
+    // failing.
+    const himmelHtml =
+      '<div>/<font color="gray">ˈhɪml̩</font>/<br>\n' +
+      '<font color="green">noun, male</font><br>\n' +
+      '  <ol>\n' +
+      '\t<li>\n' +
+      '\t  <ol>\n' +
+      '\t\t<li>Luftraum, Gewölbe über der Erde</li>\n' +
+      '\t\t<li>Religion: Aufenthaltsort im Jenseits mit Gott und den ' +
+      'Engeln, in den die Seligen nach ihrem Tode aufgenommen werden</li>\n' +
+      '\t  </ol>\n' +
+      '\t  <ol>\n' +
+      '\t\t<li><div>ciel</div></li>\n' +
+      '\t\t<li><div>paradis</div></li>\n' +
+      '\t  </ol>\n' +
+      '\t</li>\n' +
+      '\t<li>Astronomie: der Kosmos<div>ciel</div></li>\n' +
+      '\t<li>Decke aus Stoff oder ähnlichem Material\n' +
+      '\t  <ol><li><div>ciel</div></li>\n' +
+      '\t\t<li><div>dais</div></li>\n' +
+      '\t  </ol></li>\n' +
+      '  </ol>\n' +
+      '</div>';
+    const spans = htmlToSpans(himmelHtml);
+    // IPA wraps in the gray colour hint.
+    const ipa = spans.find((s) => s.text === 'ˈhɪml̩');
+    expect(ipa?.style.color).toBe('gray');
+    // POS in green.
+    const pos = spans.find((s) => s.text === 'noun, male');
+    expect(pos?.style.color).toBe('green');
+    // Sense 2's inline-div translation is bold (it's the only
+    // truly inline-mode <div> in this entry — sense 1's `ciel`/
+    // `paradis` and sense 3's `ciel`/`dais` are sole children of
+    // their <li>s, so they render in block-mode and stay un-bold).
+    const senseTwo = spans.find(
+      (s) =>
+        s.text === 'ciel' &&
+        s.style.bold === true &&
+        !s.style.color &&
+        !s.style.italic,
+    );
+    expect(senseTwo).toBeDefined();
+    // Block-mode `dais` (sole content of its <li>) is NOT bold —
+    // pin so a future renderer change can't accidentally embolden
+    // every leaf <div>. The block-mode word coalesces into the
+    // surrounding unstyled layout chunk, so we assert via "any
+    // span containing 'dais' is not bold" rather than an exact
+    // text match.
+    const daisCarriers = spans.filter((s) => s.text.includes('dais'));
+    expect(daisCarriers.length).toBeGreaterThan(0);
+    for (const carrier of daisCarriers) {
+      expect(carrier.style.bold).toBeFalsy();
+    }
+    // Visible text matches the plain-text path snapshot.
+    expect(concatText(spans)).toBe(
+      [
+        '/ˈhɪml̩/',
+        'noun, male',
+        '1.',
+        '  1. Luftraum, Gewölbe über der Erde',
+        '  2. Religion: Aufenthaltsort im Jenseits mit Gott und den Engeln, in den die Seligen nach ihrem Tode aufgenommen werden',
+        '  1. ciel',
+        '  2. paradis',
+        '2. Astronomie: der Kosmos — ciel',
+        '3. Decke aus Stoff oder ähnlichem Material',
+        '  1. ciel',
+        '  2. dais',
+      ].join('\n'),
+    );
+  });
 });
 
 describe('htmlToSpans — trim + edge cases (coverage)', () => {

--- a/__tests__/htmlToSpans.test.ts
+++ b/__tests__/htmlToSpans.test.ts
@@ -1,0 +1,377 @@
+import {htmlToSpans, type Span} from '../src/ui/htmlToSpans';
+
+// Helper: collapse a span list into the visible plain text (ignoring
+// styles). Pinned to the same shape htmlToPlainText produces — any
+// drift between the two is a bug in the shared HtmlBaseRenderer.
+const concatText = (spans: Span[]): string =>
+  spans.map((s) => s.text).join('');
+
+// Helper: extract just the text + a compact style summary per span,
+// for readable assertion failures. Style summary is "B" for bold,
+// "I" for italic, color string verbatim if present, "-" for none.
+const summary = (spans: Span[]): Array<[string, string]> =>
+  spans.map((s) => {
+    const tags: string[] = [];
+    if (s.style.bold) {
+      tags.push('B');
+    }
+    if (s.style.italic) {
+      tags.push('I');
+    }
+    if (s.style.color) {
+      tags.push(`color=${s.style.color}`);
+    }
+    return [s.text, tags.length === 0 ? '-' : tags.join(',')];
+  });
+
+describe('htmlToSpans — basic shape', () => {
+  test('empty input returns empty array', () => {
+    expect(htmlToSpans('')).toEqual([]);
+  });
+
+  test('plain text returns a single unstyled span', () => {
+    const spans = htmlToSpans('a greeting used for most purposes');
+    expect(spans).toEqual([
+      {text: 'a greeting used for most purposes', style: {}},
+    ]);
+  });
+
+  test('inline tags strip and produce a single unstyled span when no styling applies', () => {
+    const spans = htmlToSpans('<span>plain inside span</span>');
+    expect(concatText(spans)).toBe('plain inside span');
+    expect(spans.every((s) => Object.keys(s.style).length === 0)).toBe(true);
+  });
+});
+
+describe('htmlToSpans — inline styling', () => {
+  test('<b> wraps content in a bold span', () => {
+    const spans = htmlToSpans('a <b>bold</b> word');
+    expect(summary(spans)).toEqual([
+      ['a ', '-'],
+      ['bold', 'B'],
+      [' word', '-'],
+    ]);
+  });
+
+  test('<strong> is treated identically to <b>', () => {
+    expect(summary(htmlToSpans('<strong>x</strong>'))).toEqual([['x', 'B']]);
+  });
+
+  test('<i> wraps content in an italic span', () => {
+    const spans = htmlToSpans('<i>POS</i> word');
+    expect(summary(spans)).toEqual([
+      ['POS', 'I'],
+      [' word', '-'],
+    ]);
+  });
+
+  test('<em> is treated identically to <i>', () => {
+    expect(summary(htmlToSpans('<em>x</em>'))).toEqual([['x', 'I']]);
+  });
+
+  test('nested <b><i>x</i></b> merges to bold+italic on the leaf span', () => {
+    expect(summary(htmlToSpans('<b><i>x</i></b>'))).toEqual([['x', 'B,I']]);
+  });
+
+  test('<font color="green"> contributes a color hint', () => {
+    expect(summary(htmlToSpans('<font color="green">noun</font>'))).toEqual([
+      ['noun', 'color=green'],
+    ]);
+  });
+
+  test('innermost <font color> wins when nested', () => {
+    expect(
+      summary(htmlToSpans('<font color="red"><font color="blue">x</font></font>')),
+    ).toEqual([['x', 'color=blue']]);
+  });
+
+  test('<font> with no color attribute is a no-op', () => {
+    expect(summary(htmlToSpans('<font>x</font>'))).toEqual([['x', '-']]);
+  });
+});
+
+describe('htmlToSpans — layout never carries surrounding style', () => {
+  test('<i><br></i> emits an unstyled newline (layout out of italic scope)', () => {
+    // The <br> sits inside an <i> scope. The line break is layout,
+    // so the unstyled span must NOT inherit italic. Otherwise an
+    // outer italic POS scope would italicise the newline / list
+    // markers that follow inside it.
+    const spans = htmlToSpans('<i>a<br>b</i>');
+    // We expect: ["a" italic][newline unstyled]["b" italic].
+    const tagged = summary(spans);
+    expect(tagged).toContainEqual(['a', 'I']);
+    expect(tagged).toContainEqual(['b', 'I']);
+    // The newline span has no italic.
+    const newlineSpan = spans.find((s) => s.text === '\n');
+    expect(newlineSpan).toBeDefined();
+    expect(newlineSpan?.style.italic).toBeFalsy();
+  });
+
+  test('list markers emitted inside <font color> scope are unstyled', () => {
+    const spans = htmlToSpans(
+      '<font color="green"><ol><li>a</li></ol></font>',
+    );
+    // Marker chunk "1. " (with leading newline depending on
+    // position). It must NOT carry color=green even though it's
+    // emitted inside the <font> scope.
+    const marker = spans.find((s) => s.text.includes('1.'));
+    expect(marker).toBeDefined();
+    expect(marker?.style.color).toBeFalsy();
+    // The actual content "a" inherits the color.
+    const content = spans.find((s) => s.text === 'a');
+    expect(content?.style.color).toBe('green');
+  });
+});
+
+describe('htmlToSpans — list rendering matches plain-text shape', () => {
+  test('<ol><li>...</li></ol> produces "N. " markers', () => {
+    const spans = htmlToSpans('<ol><li>first</li><li>second</li></ol>');
+    expect(concatText(spans)).toBe('1. first\n2. second');
+  });
+
+  test('<ul><li>...</li></ul> produces "• " bullets', () => {
+    const spans = htmlToSpans('<ul><li>first</li><li>second</li></ul>');
+    expect(concatText(spans)).toBe('• first\n• second');
+  });
+
+  test('nested <ol> under <ol> indents inner items by 2 spaces per depth', () => {
+    const html =
+      '<ol><li>outer one<ol><li>inner a</li><li>inner b</li></ol></li>' +
+      '<li>outer two</li></ol>';
+    expect(concatText(htmlToSpans(html))).toBe(
+      '1. outer one\n  1. inner a\n  2. inner b\n2. outer two',
+    );
+  });
+});
+
+describe('htmlToSpans — translation (<div>) emboldening', () => {
+  test('inline <div> after content emits " — " unstyled and bolds the translation', () => {
+    // The exact issue #19 / #15 shape: definition body inline-followed
+    // by a <div>translation</div>.
+    const spans = htmlToSpans(
+      '<ol><li>Astronomie: der Kosmos<div>ciel</div></li></ol>',
+    );
+    // Visible text matches the plain-text path.
+    expect(concatText(spans)).toBe('1. Astronomie: der Kosmos — ciel');
+    // The translation word is bold.
+    const translationSpan = spans.find((s) => s.text === 'ciel');
+    expect(translationSpan?.style.bold).toBe(true);
+    // The em-dash separator is layout — never bold (otherwise the
+    // bold scope would visually expand past the word). Coalescing
+    // merges adjacent unstyled chunks, so the dash lives inside a
+    // larger unstyled span; assert that whichever span contains
+    // " — " is NOT bold.
+    const dashContainer = spans.find((s) => s.text.includes(' — '));
+    expect(dashContainer).toBeDefined();
+    expect(dashContainer?.style.bold).toBeFalsy();
+  });
+
+  test('multiple sibling <div> translations render with comma layout, each bold', () => {
+    const spans = htmlToSpans(
+      '<ol><li>body<div>a</div><div>b</div><div>c</div></li></ol>',
+    );
+    expect(concatText(spans)).toBe('1. body — a, b, c');
+    // a, b, c each carry bold.
+    const labelled = summary(spans);
+    expect(labelled).toContainEqual(['a', 'B']);
+    expect(labelled).toContainEqual(['b', 'B']);
+    expect(labelled).toContainEqual(['c', 'B']);
+    // The comma layout chunk is NOT bold.
+    const commaSpan = spans.find((s) => s.text === ', ');
+    expect(commaSpan).toBeDefined();
+    expect(commaSpan?.style.bold).toBeFalsy();
+  });
+
+  test('block-mode <div> (sole content of an <li>) does NOT bold', () => {
+    // When a <div> is the only content of its <li>, it renders in
+    // block mode (no em-dash). In that case the translation reads
+    // as an item body; emboldening would over-emphasise it. Per the
+    // base class rule, block-mode <div> pushes an empty style so
+    // the content stays at the popup's body weight.
+    const spans = htmlToSpans('<ol><li><div>chien</div></li></ol>');
+    expect(concatText(spans)).toBe('1. chien');
+    const word = spans.find((s) => s.text === 'chien');
+    expect(word?.style.bold).toBeFalsy();
+  });
+});
+
+describe('htmlToSpans — full Wikdict + Wiktionary entry shape', () => {
+  test('Gestirn (wikdict-de-fr): IPA grey, POS green, definition body, translation bold', () => {
+    const wikdictGestirn =
+      '<div>/<font color="gray">ɡəˈʃtɪʁn</font>/<br>' +
+      '<font color="green">noun, neutral</font><br>' +
+      'Astronomie, gehoben, meist im Plural: Himmelskörper im ' +
+      'Allgemeinen, welcher am Nachthimmel sichtbar ist' +
+      '<div>astre</div></div>';
+    const spans = htmlToSpans(wikdictGestirn);
+    const text = concatText(spans);
+    expect(text).toContain('/ɡəˈʃtɪʁn/');
+    expect(text).toContain('noun, neutral');
+    expect(text).toContain('Astronomie');
+    expect(text).toMatch(/sichtbar ist — astre/);
+    // IPA carries the grey colour hint from the dict.
+    const ipa = spans.find((s) => s.text === 'ɡəˈʃtɪʁn');
+    expect(ipa?.style.color).toBe('gray');
+    // POS carries the green colour hint.
+    const pos = spans.find((s) => s.text === 'noun, neutral');
+    expect(pos?.style.color).toBe('green');
+    // Translation is bold.
+    const translation = spans.find((s) => s.text === 'astre');
+    expect(translation?.style.bold).toBe(true);
+  });
+
+  test('Hund-style nested <ol> with <div> translations: nested numbering, no bold (block-mode)', () => {
+    const wikdictHund =
+      '<div><font color="green">noun, male</font><br><ol>' +
+      '<li>Haustier, dessen Vorfahre der Wolf ist<ol>' +
+      '<li><div>chien</div></li>' +
+      '<li><div>chienne</div></li>' +
+      '</ol></li></ol></div>';
+    const spans = htmlToSpans(wikdictHund);
+    expect(concatText(spans)).toBe(
+      'noun, male\n1. Haustier, dessen Vorfahre der Wolf ist\n  1. chien\n  2. chienne',
+    );
+    // chien / chienne are leaf <div>s but block-mode (sole content
+    // of their <li>) — so they are NOT bold. This matches the
+    // base-class rule and the plain-text path's expectation.
+    expect(spans.find((s) => s.text === 'chien')?.style.bold).toBeFalsy();
+    expect(spans.find((s) => s.text === 'chienne')?.style.bold).toBeFalsy();
+    // POS still bears the green hint.
+    expect(spans.find((s) => s.text === 'noun, male')?.style.color).toBe(
+      'green',
+    );
+  });
+});
+
+describe('htmlToSpans — trim + edge cases (coverage)', () => {
+  test('NBSP between body and inline <div> is trimmed before em-dash', () => {
+    // Hits the trimTrailingInlineWhitespace path: NBSP-only tail
+    // gets stripped before the em-dash separator is emitted.
+    const html =
+      '<div>Definition body&nbsp;<div>translation</div></div>';
+    const spans = htmlToSpans(html);
+    expect(concatText(spans)).toBe('Definition body — translation');
+    // No span retains the NBSP that originally sat between body
+    // and translation (proves trim ran rather than the post-pass
+    // happening to elide it).
+    expect(spans.some((s) => s.text.includes('\u00a0'))).toBe(false);
+  });
+
+  test('trim helper drops a tail span that is entirely whitespace (different style)', () => {
+    // Span sequence: ["foo" bold, " " italic, then inline <div>].
+    // The italic-only-space tail becomes whole-span whitespace; the
+    // trim helper pops it so the em-dash adjoins "foo" cleanly.
+    const html = '<b>foo</b><i> </i><div>tr</div>';
+    const spans = htmlToSpans(html);
+    expect(concatText(spans)).toBe('foo — tr');
+    // The italic-only-space tail is gone after trim.
+    expect(spans.some((s) => s.style.italic && s.text.trim() === '')).toBe(
+      false,
+    );
+  });
+
+  test('trim helper walks multiple all-whitespace tail spans', () => {
+    // Three nested tail spans of pure whitespace, each with
+    // different styles → trim must pop more than one before
+    // landing on the real body content.
+    const html =
+      '<b>foo</b><i> </i><font color="red"> </font><div>tr</div>';
+    expect(concatText(htmlToSpans(html))).toBe('foo — tr');
+  });
+
+  test('translation following a sole-whitespace last span renders inline', () => {
+    // Pin: even when an upstream `<i> </i>` sits between body and
+    // <div>, the inline em-dash still applies (whitespace-only
+    // inter-tag content is whitespace from contentOnLine's POV).
+    const html = '<b>body</b> <div>tr</div>';
+    expect(concatText(htmlToSpans(html))).toBe('body — tr');
+  });
+
+  test('block-mode <div> close emits a newline so adjacent block-divs separate', () => {
+    // Sequence of two block-mode <div>s at top level: each closes
+    // with a newline, ensuring the second renders on its own line.
+    const spans = htmlToSpans('<div>a</div><div>b</div>');
+    expect(concatText(spans)).toBe('a\nb');
+  });
+
+  test('stray </div> with no matching open does not throw (defensive pop)', () => {
+    // Empty inlineDivStack → handleDivClose's `?? false` branch.
+    // The renderer must not throw; the orphan close emits a
+    // block-mode newline.
+    expect(() => htmlToSpans('orphan</div>tail')).not.toThrow();
+  });
+
+  test('</br> close tag is a no-op (br only emits on open)', () => {
+    // Hits the close-side branch of <br> handling: the renderer
+    // ignores the close, leaving content adjacent.
+    expect(concatText(htmlToSpans('a</br>b'))).toBe('ab');
+  });
+
+  test('whitespace-only line at line-start renders as no line at all', () => {
+    // Hits the line-empty filter: a line whose only content is the
+    // indent + whitespace chunk (no real content) is dropped.
+    const spans = htmlToSpans('<br>   <br>real');
+    expect(concatText(spans)).toBe('real');
+  });
+
+  test('normalise step-2 trim drops a whole-whitespace tail chunk (different style)', () => {
+    // Tail chunk after normalise is a different-style space-only
+    // run, so step-2 trim must pop the chunk entirely (line 244-245
+    // in htmlToSpans.ts). Without this branch, the rendered text
+    // would carry a trailing space that shifts the visible width.
+    const spans = htmlToSpans('<ol><li>text<i> </i></li></ol>');
+    expect(concatText(spans)).toBe('1. text');
+  });
+
+  test('normalise step-2 trim partially trims trailing whitespace from tail chunk', () => {
+    // Tail chunk has content + trailing space. Step-2 trims just
+    // the trailing whitespace (line 248 in htmlToSpans.ts).
+    const spans = htmlToSpans('<ol><li>text </li></ol>');
+    expect(concatText(spans)).toBe('1. text');
+  });
+
+  test('content with only inline tags and no text yields empty span list', () => {
+    // Hits the normalise empty-input fast path (line 144) — the
+    // span renderer was constructed (no fast-path return), but no
+    // emitText / emitLayout fired, so the buffer is empty.
+    expect(htmlToSpans('<span></span>')).toEqual([]);
+  });
+});
+
+describe('htmlToSpans — text matches htmlToPlainText byte-for-byte', () => {
+  // Cross-renderer invariant: visible characters from htmlToSpans
+  // must equal what htmlToPlainText produces. Any divergence means
+  // the base class is being used inconsistently.
+  test.each([
+    ['plain', 'a greeting used for most purposes'],
+    ['inline tags', '<i>intj</i>'],
+    ['br', 'a<br>b<br/>c<br />d'],
+    ['ol', '<ol><li>first</li><li>second</li></ol>'],
+    ['ul', '<ul><li>first</li><li>second</li></ul>'],
+    [
+      'nested ol',
+      '<ol><li>outer<ol><li>inner a</li><li>inner b</li></ol></li><li>outer 2</li></ol>',
+    ],
+    [
+      'Gestirn',
+      '<div>/<font color="gray">ɡəˈʃtɪʁn</font>/<br><font color="green">noun, neutral</font><br>Astronomie, gehoben, meist im Plural: Himmelskörper im Allgemeinen, welcher am Nachthimmel sichtbar ist<div>astre</div></div>',
+    ],
+    [
+      'Himmel inline',
+      '<ol><li>Astronomie: der Kosmos<div>ciel</div></li></ol>',
+    ],
+    [
+      'multi-translations',
+      '<ol><li>Decke aus Stoff oder ähnlichem Material<div>ciel</div><div>dais</div></li></ol>',
+    ],
+    [
+      'Hund',
+      '<div><font color="green">noun, male</font><br><ol><li>Haustier, dessen Vorfahre der Wolf ist<ol><li><div>chien</div></li><li><div>chienne</div></li></ol></li></ol></div>',
+    ],
+    ['entities', 'AT&amp;T &lt; &gt; &nbsp;&#65;'],
+  ])('%s', (_label, html) => {
+    // Lazily import to keep the cross-renderer invariant explicit.
+    const {htmlToPlainText} = require('../src/ui/htmlToPlainText');
+    expect(concatText(htmlToSpans(html))).toBe(htmlToPlainText(html));
+  });
+});

--- a/__tests__/integration/manifest.ts
+++ b/__tests__/integration/manifest.ts
@@ -97,6 +97,45 @@ export const MANIFEST: DictManifest[] = [
         // Inner <ol> renders at depth 2 (two-space indent).
         matches: [/ {2}1\. chien\n {2}2\. chienne/],
       },
+      {
+        // Issue #19's worked example. Mixes all three v1.0.9 cases
+        // in one entry:
+        //   - sense 2 has a `body<div>tr</div>` inline em-dash join,
+        //   - sense 1 has a sibling `<ol>` of pure-<div> translations
+        //     (block-mode numbered items at depth 2),
+        //   - sense 3 has a body line followed by a nested numbered
+        //     list of translations.
+        // Single integration entry covering the whole shape so a
+        // future renderer change against the real .dict body is a
+        // visible failure here.
+        word: 'Himmel',
+        contains: [
+          'ˈhɪml̩', // IPA
+          'noun, male', // POS
+          'Luftraum', // sense 1 inner item 1
+          'Religion:', // sense 1 inner item 2
+          'Astronomie: der Kosmos — ciel', // sense 2 inline em-dash
+          'Decke aus Stoff', // sense 3 body
+          '  1. ciel',
+          '  2. dais',
+        ],
+        notContains: [
+          // No glue across the inline-translation boundary.
+          'Kosmosciel',
+          // No v1.0.8 newline-only shape for the inline case.
+          'Kosmos\nciel',
+          // Bullets are gone in v1.0.9.
+          '• ciel',
+          '• dais',
+        ],
+        matches: [
+          // Sense 2 em-dash join.
+          /Astronomie: der Kosmos\s+—\s+ciel/,
+          // Sense 3 body followed immediately by depth-2 numbered
+          // translations (no blank line, no fall-through bullet).
+          /Decke aus Stoff[^\n]*\n {2}1\. ciel\n {2}2\. dais/,
+        ],
+      },
     ],
   },
   {

--- a/__tests__/integration/manifest.ts
+++ b/__tests__/integration/manifest.ts
@@ -63,9 +63,10 @@ export const MANIFEST: DictManifest[] = [
     description: 'WikDict German→French (Wiktionary-derived, CC-BY-SA)',
     entries: [
       {
-        // The exact entry from issue #15. Pre-fix output glued
-        // "ist" and "astre" into "istastre"; post-fix the
-        // translation lands on its own line.
+        // The exact entry from issue #15.
+        //   - v1.0.6 glued "ist" and "astre" into "istastre".
+        //   - v1.0.8 split them onto separate lines.
+        //   - v1.0.9 (issue #19) joins them inline with " — ".
         word: 'Gestirn',
         contains: [
           'ɡəˈʃtɪʁn', // IPA
@@ -74,19 +75,27 @@ export const MANIFEST: DictManifest[] = [
           'astre', // French translation
         ],
         notContains: ['istastre'],
-        matches: [/sichtbar ist\s*\n+\s*astre/],
+        // Em-dash separator between body and translation. The pin
+        // is loose around whitespace either side of "—" because
+        // upstream sometimes carries NBSP / multi-space before
+        // the translation; the renderer normalises but the regex
+        // shouldn't fight it.
+        matches: [/sichtbar ist\s+—\s+astre/],
       },
       {
         // Multi-translation entry under <ol><li><div>...</div></li>.
-        // Bullets must survive AND each translation must be on its
-        // own line.
+        // Each translation is the SOLE content of an inner <li>, so
+        // the renderer keeps them as numbered (block-mode) items
+        // rather than em-dash inline. v1.0.9 numbering replaces the
+        // v1.0.8 "• " bullets.
         word: 'Hund',
-        contains: ['noun, male', '• chien', '• chienne'],
+        contains: ['noun, male', '1. chien', '2. chienne'],
         // Pre-fix forms: "ist<div>chien" produced "istchien" type
-        // glue; the bullets should never collapse into a single
-        // run of text.
-        notContains: ['istchien', 'chien• chienne'],
-        matches: [/• chien\s*\n\s*• chienne/],
+        // glue; the numbered items must never collapse into a
+        // single run of text.
+        notContains: ['istchien', 'chien2. chienne', '• chien'],
+        // Inner <ol> renders at depth 2 (two-space indent).
+        matches: [/ {2}1\. chien\n {2}2\. chienne/],
       },
     ],
   },
@@ -102,18 +111,19 @@ export const MANIFEST: DictManifest[] = [
         // first match for "chien" is the (Astrologie) zodiac entry,
         // not the canine — both are present, and which is "first" is
         // a property of the .idx ordering pinned by the SHA above.
-        // Either way, the glue invariant is what matters: definition
-        // body must not run into the German translation.
+        // The glue invariant is what matters: definition body must
+        // not run into the German translation. v1.0.9 expects
+        // em-dash join.
         word: 'chien',
         contains: ['ʃjɛ̃', 'Astrologie', 'zodiaque chinois', 'Hund'],
         notContains: ['chinoisHund'],
-        matches: [/chinois\s*\n+\s*Hund/],
+        matches: [/chinois\s+—\s+Hund/],
       },
       {
         word: 'maison',
         contains: ['mɛ.zɔ̃', 'adjective', 'Familier', 'hausgemacht'],
         notContains: ['maisonhausgemacht'],
-        matches: [/maison\s*\n+\s*hausgemacht/],
+        matches: [/maison\s+—\s+hausgemacht/],
       },
     ],
   },
@@ -126,9 +136,11 @@ export const MANIFEST: DictManifest[] = [
     entries: [
       {
         word: 'Buch',
-        contains: ['buːx', 'noun, neutral', 'Schriftwerk', '• book'],
-        notContains: ['Blattgold<', 'Blattgoldbook'],
-        matches: [/• book/],
+        // v1.0.9: translations under nested <ol><li><div>book</div></li>
+        // render as numbered items at depth 2 (block-mode div).
+        contains: ['buːx', 'noun, neutral', 'Schriftwerk', 'book'],
+        notContains: ['Blattgold<', 'Blattgoldbook', '• book'],
+        matches: [/ {2}\d+\. book/],
       },
     ],
   },

--- a/src/ui/HtmlText.tsx
+++ b/src/ui/HtmlText.tsx
@@ -1,0 +1,72 @@
+// React Native renderer for HTML-formatted dictionary entries.
+//
+// Wraps a single root <Text> with one nested <Text> per non-empty
+// styled span produced by htmlToSpans. Bold / italic / colour are
+// applied per span; layout characters (newlines, indents, list
+// markers, em-dashes) inherit only the popup's base style so they
+// can never accidentally pick up an outer <i>POS</i> scope.
+//
+// Why a single root <Text> with nested children (and not a tree of
+// <View><Text>...</Text></View> rows for lists): RN's <Text>
+// composes inline styles cleanly when nested, and embedded \n
+// produces the same visible layout an indented View tree would.
+// Going wider would let us right-align numbers or hang-indent
+// wrapped content, but at the cost of measurable component-tree
+// size for entries with 50+ list items. The popup's body is also
+// already inside a ScrollView; the tighter the tree, the smoother
+// the e-ink scroll.
+
+import React, {useMemo} from 'react';
+import {Text, type StyleProp, type TextStyle} from 'react-native';
+import {htmlToSpans, type SpanStyle} from './htmlToSpans';
+
+type HtmlTextProps = {
+  html: string;
+  // Applied to the root <Text>. Children inherit font size, line
+  // height, base colour, etc. via RN's Text-nesting rules. The body
+  // style for definition text in this app is popupStyles.definition,
+  // optionally scaled by the user's font-size selection.
+  style?: StyleProp<TextStyle>;
+};
+
+const styleForSpan = (s: SpanStyle): TextStyle | undefined => {
+  if (!s.bold && !s.italic && !s.color) {
+    return undefined;
+  }
+  const out: TextStyle = {};
+  if (s.bold) {
+    out.fontWeight = '700';
+  }
+  if (s.italic) {
+    out.fontStyle = 'italic';
+  }
+  if (s.color) {
+    out.color = s.color;
+  }
+  return out;
+};
+
+export const HtmlText = ({html, style}: HtmlTextProps): React.JSX.Element => {
+  // Memoise both the parse and the per-span style materialisation.
+  // The popup re-renders on font-size changes (style prop changes),
+  // but the underlying html string stays stable for a given lookup
+  // — so the spans + their styleForSpan results don't churn.
+  const children = useMemo(() => {
+    const spans = htmlToSpans(html);
+    return spans.map((span, i) => {
+      const spanStyle = styleForSpan(span.style);
+      // Don't wrap unstyled spans in their own <Text>; emit the raw
+      // string. Trims tree depth for the common case (most layout
+      // chunks + plain body text).
+      if (!spanStyle) {
+        return span.text;
+      }
+      return (
+        <Text key={i} style={spanStyle}>
+          {span.text}
+        </Text>
+      );
+    });
+  }, [html]);
+  return <Text style={style}>{children}</Text>;
+};

--- a/src/ui/SourceSection.tsx
+++ b/src/ui/SourceSection.tsx
@@ -19,7 +19,7 @@ import {Text, View} from 'react-native';
 import type {SourceHit} from '../core/lookup';
 import {parseWordNetEntry} from './wordnetFormatter';
 import {SenseList} from './senseBlocks';
-import {htmlToPlainText} from './htmlToPlainText';
+import {HtmlText} from './HtmlText';
 import {popupStyles as styles} from './popupStyles';
 
 type SourceSectionProps = {
@@ -57,7 +57,9 @@ export const SourceSection = ({
       return <Text style={scaledDefinitionStyle}>{definition}</Text>;
     }
     if (format === 'html') {
-      return <Text style={scaledDefinitionStyle}>{htmlToPlainText(definition)}</Text>;
+      // Rich path (v1.0.9): translations bold, POS italic / coloured,
+      // numbered lists indented. See HtmlText.tsx + htmlToSpans.ts.
+      return <HtmlText html={definition} style={scaledDefinitionStyle} />;
     }
     // 'plain'
     return <Text style={scaledDefinitionStyle}>{definition}</Text>;

--- a/src/ui/htmlParser.ts
+++ b/src/ui/htmlParser.ts
@@ -1,0 +1,220 @@
+// Shared HTML tokenizer used by every dictionary-entry render path.
+//
+// Why a tokenizer (vs. continuing the inline state-machine pattern
+// `htmlToPlainText` shipped in v1.0.6): two consumers now share the
+// same parse — the plain-text reducer used by tests + non-RN paths,
+// and the React Native span renderer that emits nested <Text> for
+// bold / italic / colour. Doing the parse twice would be wasted work
+// and a divergence hazard. A single visitor-style emitter keeps the
+// tag set, entity table, and malformed-tag handling in one place.
+//
+// Design constraints carried over from htmlToPlainText:
+//   - Single-pass, no DOM library, no regex over the whole string.
+//     RN's JS engine has no DOMParser; pulling in an HTML parser is
+//     overkill for the structural tag set dicts use.
+//   - Entity decoding for the small set Wikdict / Wiktionary actually
+//     emit (named + numeric), with a 20-char ceiling to keep runaway
+//     `&...` from a malformed body cheap.
+//   - Malformed unclosed tags surface as literal text rather than
+//     silently swallowing the rest of the entry.
+
+export type TagInfo = {
+  // Lowercased tag name with no leading slash.
+  name: string;
+  // True for `</foo>`, false for `<foo>` and `<foo/>`. Self-closing
+  // detection is left to the caller — `<br>` and `<br/>` both arrive
+  // as `{name:'br', isClose:false}`. Tags whose close tag is
+  // semantically a no-op (br, hr) are typically handled by ignoring
+  // close-side events for that name.
+  isClose: boolean;
+  // Attribute map, lowercased keys, raw (entity-undecoded) values.
+  // Kept lazy-ish: we only parse the inside of the tag once per
+  // open/close, but every consumer pays the cost. In practice tag
+  // attribute counts in dict HTML are tiny (`<font color="green">`,
+  // `<a href="...">`) so this never shows up in profiling.
+  attrs: Record<string, string>;
+};
+
+export type HtmlVisitor = {
+  // Called for each contiguous run of decoded text content. NEVER
+  // called with the empty string — the parser elides empty flushes.
+  onText(text: string): void;
+  // Called for every tag boundary (open and close). Self-closing
+  // tags (`<br/>`) emit a single `{isClose:false}` event — close-side
+  // is the consumer's responsibility for tags where it matters.
+  onTag(tag: TagInfo): void;
+};
+
+const ENTITY_MAP: Record<string, string> = {
+  amp: '&',
+  lt: '<',
+  gt: '>',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+const decodeEntity = (entity: string): string => {
+  if (entity.length === 0) {
+    return '';
+  }
+  if (entity[0] === '#') {
+    const isHex = entity[1] === 'x' || entity[1] === 'X';
+    const codepoint = isHex
+      ? parseInt(entity.slice(2), 16)
+      : parseInt(entity.slice(1), 10);
+    if (Number.isFinite(codepoint) && codepoint > 0 && codepoint <= 0x10ffff) {
+      try {
+        return String.fromCodePoint(codepoint);
+      } catch {
+        return '';
+      }
+    }
+    return '';
+  }
+  return ENTITY_MAP[entity.toLowerCase()] ?? '';
+};
+
+const HAS_HTML_TAG = /<\/?[a-zA-Z][^>]*>/;
+
+// Lowercased tag name without the leading slash. Stops at the first
+// whitespace, `/`, or `>` after the name.
+const tagNameOf = (rawTag: string): string => {
+  const trimmed = rawTag.trim();
+  const stripped = trimmed.startsWith('/') ? trimmed.slice(1) : trimmed;
+  const spaceOrSlash = stripped.search(/[\s/>]/);
+  return (
+    spaceOrSlash < 0 ? stripped : stripped.slice(0, spaceOrSlash)
+  ).toLowerCase();
+};
+
+// Parse the body of a tag (e.g. `font color="green" size="3"`) into
+// an attribute map. Tolerant of the loose attribute syntax dict HTML
+// uses in practice: unquoted values, missing values, mixed quote
+// styles. Quote-stripping is shallow — entity decoding inside the
+// value is left to consumers, since attribute values almost never
+// carry entities in dict bodies.
+const parseTagAttrs = (rawTag: string): Record<string, string> => {
+  const attrs: Record<string, string> = {};
+  const start = rawTag.startsWith('/') ? 1 : 0;
+  let i = start;
+  // Skip the tag name itself.
+  while (i < rawTag.length && !/[\s/>]/.test(rawTag[i])) {
+    i++;
+  }
+  while (i < rawTag.length) {
+    // Skip any whitespace between attributes.
+    while (i < rawTag.length && /\s/.test(rawTag[i])) {
+      i++;
+    }
+    if (i >= rawTag.length || rawTag[i] === '/' || rawTag[i] === '>') {
+      break;
+    }
+    const nameStart = i;
+    while (i < rawTag.length && !/[\s=/>]/.test(rawTag[i])) {
+      i++;
+    }
+    const name = rawTag.slice(nameStart, i).toLowerCase();
+    while (i < rawTag.length && /\s/.test(rawTag[i])) {
+      i++;
+    }
+    if (rawTag[i] !== '=') {
+      // Boolean / valueless attribute (`<input disabled>`-style).
+      // Dict HTML doesn't use these, but recording them as empty
+      // string keeps the consumer contract simple.
+      attrs[name] = '';
+      continue;
+    }
+    i++; // consume '='
+    while (i < rawTag.length && /\s/.test(rawTag[i])) {
+      i++;
+    }
+    let value = '';
+    if (rawTag[i] === '"' || rawTag[i] === "'") {
+      const quote = rawTag[i];
+      i++;
+      const valStart = i;
+      while (i < rawTag.length && rawTag[i] !== quote) {
+        i++;
+      }
+      value = rawTag.slice(valStart, i);
+      if (i < rawTag.length) {
+        i++; // consume closing quote
+      }
+    } else {
+      const valStart = i;
+      while (i < rawTag.length && !/[\s/>]/.test(rawTag[i])) {
+        i++;
+      }
+      value = rawTag.slice(valStart, i);
+    }
+    attrs[name] = value;
+  }
+  return attrs;
+};
+
+// Returns true if the input looks like HTML (contains at least one
+// well-formed-looking tag). Lets the popup short-circuit and skip
+// the tokenizer for plain text.
+export const looksLikeHtml = (s: string): boolean => HAS_HTML_TAG.test(s);
+
+// Walk `html` and dispatch text + tag events to `visitor`. Idempotent
+// on input with no tags AND no entities (visitor.onText receives the
+// whole string in one call). Malformed unclosed tags are surfaced as
+// literal text via onText so the trailing content isn't lost.
+export const parseHtml = (html: string, visitor: HtmlVisitor): void => {
+  if (html.length === 0) {
+    return;
+  }
+  // Fast path: no markup of any kind. One text event, no scanning.
+  if (!looksLikeHtml(html) && html.indexOf('&') < 0) {
+    visitor.onText(html);
+    return;
+  }
+  let buf = '';
+  let i = 0;
+  const flush = (): void => {
+    if (buf.length > 0) {
+      visitor.onText(buf);
+      buf = '';
+    }
+  };
+  while (i < html.length) {
+    const ch = html[i];
+    if (ch === '<') {
+      const end = html.indexOf('>', i);
+      if (end < 0) {
+        // Malformed: no closing '>'. Treat the rest as text rather
+        // than silently dropping the suffix.
+        buf += html.slice(i);
+        break;
+      }
+      flush();
+      const inner = html.slice(i + 1, end);
+      const isClose = inner.trim().startsWith('/');
+      visitor.onTag({
+        name: tagNameOf(inner),
+        isClose,
+        attrs: parseTagAttrs(inner),
+      });
+      i = end + 1;
+    } else if (ch === '&') {
+      const semi = html.indexOf(';', i);
+      // Entity references are short. If we can't find a ';' within
+      // 20 chars, treat the '&' as literal. The limit covers long
+      // numeric entities AND verbose-but-reasonable named ones;
+      // anything longer is almost certainly not an entity.
+      if (semi < 0 || semi - i > 20) {
+        buf += '&';
+        i++;
+      } else {
+        buf += decodeEntity(html.slice(i + 1, semi));
+        i = semi + 1;
+      }
+    } else {
+      buf += ch;
+      i++;
+    }
+  }
+  flush();
+};

--- a/src/ui/htmlRenderBase.ts
+++ b/src/ui/htmlRenderBase.ts
@@ -1,0 +1,228 @@
+// Shared layout state machine for HTML→{plain text, RN spans}
+// renderers. The parser (htmlParser.ts) emits the raw token stream;
+// this base class encodes the structural rendering rules (numbered
+// lists, indented bullets, inline em-dash translations, NBSP-aware
+// line-state tracking) so both consumers stay in lockstep.
+//
+// Subclasses plug in two output sinks:
+//   emitText(s)   — renders user-visible textual content, in whatever
+//                   form the consumer wants (string append, span
+//                   buffer, …). Called once per onText event.
+//   emitLayout(s) — renders structural characters (newlines, indents,
+//                   em-dash separators, list markers). Subclasses
+//                   typically render these in the "default" style
+//                   bucket so layout doesn't pick up bold / italic
+//                   from a surrounding style scope.
+//
+// Style hooks (pushStyle / popStyle) default to no-ops so the
+// plain-text renderer can ignore them. The span renderer overrides
+// to maintain a style stack. The base class always pairs a push
+// with a pop on every <div> open/close so style-stack subclasses
+// stay balanced even when div-mode swaps from inline to block.
+
+import {type HtmlVisitor, type TagInfo} from './htmlParser';
+
+export type ListFrame = {
+  // Whether items are numbered (ol) or bulleted (ul). A stray <li>
+  // without an enclosing list defaults to ul-style "•".
+  kind: 'ol' | 'ul';
+  // 1-based item counter, incremented on each <li> open.
+  counter: number;
+};
+
+export type StyleHint = {
+  bold?: boolean;
+  italic?: boolean;
+  // Colour hint from <font color="..."> attributes. Empty string =
+  // no colour (kept distinct from `undefined` so a future renderer
+  // could distinguish "tag had color attr but value was empty" from
+  // "tag had no color attr").
+  color?: string;
+};
+
+export abstract class HtmlBaseRenderer implements HtmlVisitor {
+  protected listStack: ListFrame[] = [];
+
+  // True once a non-whitespace, non-marker character has been emitted
+  // on the current logical line. Drives the inline-vs-block <div>
+  // decision: only "real" preceding content promotes a <div> to
+  // inline em-dash. List markers don't qualify (`<li><div>x</div>`
+  // still renders as "1. x", not "1.  — x").
+  protected contentOnLine = false;
+
+  // One slot per open <div>: true if it opened in inline-mode
+  // (em-dash / comma join), false if block-mode (line-start).
+  // Stack so nested inline divs (rare but valid) compose.
+  protected inlineDivStack: boolean[] = [];
+
+  // True immediately after an inline </div> closes, until the next
+  // tag or non-whitespace text. Lets a peer <div> sibling open with
+  // ", " (comma list) instead of repeating " — ".
+  protected justClosedInlineDiv = false;
+
+  onText(text: string): void {
+    for (const ch of text) {
+      if (ch === '\n') {
+        this.contentOnLine = false;
+        this.justClosedInlineDiv = false;
+      } else if (ch !== ' ' && ch !== '\t' && ch !== ' ') {
+        // U+00A0 NBSP counts as whitespace here so a Wikdict shape
+        // with `&nbsp;<div>` doesn't escape the un-glue rule.
+        this.contentOnLine = true;
+        this.justClosedInlineDiv = false;
+      }
+    }
+    this.emitText(text);
+  }
+
+  onTag(tag: TagInfo): void {
+    const {name, isClose, attrs} = tag;
+    switch (name) {
+      case 'br':
+        if (!isClose) {
+          this.emitNewline();
+        }
+        return;
+      case 'p':
+        // Paragraph break: two newlines now; the per-line dedup in
+        // most consumers collapses adjacent blank lines.
+        if (!isClose) {
+          this.emitNewline();
+          this.emitNewline();
+        }
+        return;
+      case 'ol':
+      case 'ul':
+        if (isClose) {
+          this.listStack.pop();
+        } else {
+          this.listStack.push({kind: name, counter: 0});
+        }
+        this.justClosedInlineDiv = false;
+        return;
+      case 'li':
+        if (!isClose) {
+          this.emitListItemMarker();
+        }
+        return;
+      case 'div':
+        if (isClose) {
+          this.handleDivClose();
+        } else {
+          this.handleDivOpen();
+        }
+        return;
+      case 'b':
+      case 'strong':
+        if (isClose) {
+          this.popStyle();
+        } else {
+          this.pushStyle({bold: true});
+        }
+        return;
+      case 'i':
+      case 'em':
+        if (isClose) {
+          this.popStyle();
+        } else {
+          this.pushStyle({italic: true});
+        }
+        return;
+      case 'font':
+        if (isClose) {
+          this.popStyle();
+        } else {
+          this.pushStyle({color: attrs.color ?? ''});
+        }
+        return;
+      default:
+        // Inline / decorative tags we don't recognise (span, a, …)
+        // drop — content keeps flowing through onText.
+        return;
+    }
+  }
+
+  // -- subclass hooks --
+
+  // Renders a chunk of user-visible content. Receives raw text from
+  // the parser, possibly containing whitespace runs and newlines —
+  // subclasses post-process / segment as needed.
+  protected abstract emitText(text: string): void;
+
+  // Renders structural characters (newlines, indents, em-dashes,
+  // list markers, comma joiners). Must NOT be styled with the
+  // surrounding bold / italic / colour scope.
+  protected abstract emitLayout(text: string): void;
+
+  // Default no-op style hooks. The plain-text renderer ignores
+  // styles entirely; the span renderer overrides both.
+  protected pushStyle(_style: StyleHint): void {
+    // intentional no-op
+  }
+  protected popStyle(): void {
+    // intentional no-op
+  }
+
+  // Strip trailing inline-whitespace (space, tab, NBSP) from the
+  // already-emitted output. Called immediately before an inline
+  // separator (` — ` / `, `) is emitted so a trailing NBSP from
+  // the body (e.g. Wikdict's `body&nbsp;<div>translation</div>`)
+  // doesn't visually double up next to the separator. Default
+  // no-op — subclasses override only if they keep mutable state.
+  protected trimTrailingInlineWhitespace(): void {
+    // intentional no-op
+  }
+
+  // -- shared layout helpers --
+
+  protected emitNewline(): void {
+    this.emitLayout('\n');
+    this.contentOnLine = false;
+    this.justClosedInlineDiv = false;
+  }
+
+  protected emitListItemMarker(): void {
+    const top = this.listStack[this.listStack.length - 1];
+    const depth = this.listStack.length;
+    const indent = '  '.repeat(Math.max(0, depth - 1));
+    if (top) {
+      top.counter++;
+      const marker = top.kind === 'ol' ? `${top.counter}. ` : '• ';
+      this.emitLayout(`\n${indent}${marker}`);
+    } else {
+      // <li> outside any list. Bullet at depth 0.
+      this.emitLayout('\n• ');
+    }
+    this.contentOnLine = false;
+    this.justClosedInlineDiv = false;
+  }
+
+  protected handleDivOpen(): void {
+    if (this.contentOnLine) {
+      this.trimTrailingInlineWhitespace();
+      this.emitLayout(this.justClosedInlineDiv ? ', ' : ' — ');
+      this.inlineDivStack.push(true);
+      this.justClosedInlineDiv = false;
+      // Inline-translation styling: bold makes the user-visible
+      // distinction between the definition body and the
+      // translation pop. Plain-text path no-ops this push.
+      this.pushStyle({bold: true});
+    } else {
+      this.inlineDivStack.push(false);
+      // Block-mode <div>: push an empty style so the matching
+      // popStyle on close stays balanced regardless of mode.
+      this.pushStyle({});
+    }
+  }
+
+  protected handleDivClose(): void {
+    const wasInline = this.inlineDivStack.pop() ?? false;
+    // Always pop — handleDivOpen always pushes (inline or empty).
+    this.popStyle();
+    if (wasInline) {
+      this.justClosedInlineDiv = true;
+    } else {
+      this.emitNewline();
+    }
+  }
+}

--- a/src/ui/htmlToPlainText.ts
+++ b/src/ui/htmlToPlainText.ts
@@ -1,166 +1,78 @@
-// Convert HTML-formatted definition text into plain text suitable for
-// the popup's fallback render path. Used for StarDict dicts whose
-// .ifo declares `sametypesequence=h` (Wiktionary-derived dicts in
-// particular), and as a safety net for any user-authored CSV/JSON
-// definition that happens to contain HTML.
+// Plain-text consumer of the shared HTML renderer base.
 //
-// Design constraints:
-// - Single-pass, no DOM, no regex over the whole string. RN's JS engine
-//   has no DOMParser; pulling in an HTML parser library is overkill for
-//   the structural-tag set dicts use in practice.
-// - Idempotent on plain text (no `<` or `&` -> output equals input
-//   modulo whitespace collapse). WordNet entries flow through
-//   untouched; the existing parseWordNetEntry path still runs first.
-// - Conservative tag handling: known structural tags get layout
-//   substitutions; everything else is dropped (content kept).
+// Public API (unchanged since v1.0.6):
+//   - htmlToPlainText(html) → string
+//   - looksLikeHtml(html)   → boolean
+//
+// Rendering rules are documented on HtmlBaseRenderer; this file
+// supplies the string-buffer sink and per-line whitespace
+// normalisation. Style hooks (bold / italic / colour) are inherited
+// no-ops — the plain-text path strips styling and only carries
+// layout-level structure.
 
-const ENTITY_MAP: Record<string, string> = {
-  amp: '&',
-  lt: '<',
-  gt: '>',
-  quot: '"',
-  apos: "'",
-  nbsp: ' ',
-};
+import {parseHtml, looksLikeHtml} from './htmlParser';
+import {HtmlBaseRenderer} from './htmlRenderBase';
 
-const decodeEntity = (entity: string): string => {
-  if (entity.length === 0) {
-    return '';
+export {looksLikeHtml};
+
+class PlainTextRenderer extends HtmlBaseRenderer {
+  private out = '';
+
+  protected emitText(text: string): void {
+    this.out += text;
   }
-  if (entity[0] === '#') {
-    const isHex = entity[1] === 'x' || entity[1] === 'X';
-    const codepoint = isHex
-      ? parseInt(entity.slice(2), 16)
-      : parseInt(entity.slice(1), 10);
-    if (Number.isFinite(codepoint) && codepoint > 0 && codepoint <= 0x10ffff) {
-      try {
-        return String.fromCodePoint(codepoint);
-      } catch {
-        return '';
-      }
+
+  protected emitLayout(text: string): void {
+    this.out += text;
+  }
+
+  protected trimTrailingInlineWhitespace(): void {
+    // Walk back over space / tab / NBSP. Stops at any other char
+    // (including \n, which signals a previous line — that case is
+    // already handled by contentOnLine being false in handleDivOpen,
+    // so we wouldn't reach here from line-start).
+    let end = this.out.length;
+    while (
+      end > 0 &&
+      (this.out[end - 1] === ' ' ||
+        this.out[end - 1] === '\t' ||
+        this.out[end - 1] === ' ')
+    ) {
+      end--;
     }
-    return '';
+    if (end < this.out.length) {
+      this.out = this.out.slice(0, end);
+    }
   }
-  return ENTITY_MAP[entity.toLowerCase()] ?? '';
-};
 
-// Identify the bare tag name from "<i>", "</i>", "<br/>", "<li class=x>".
-// Returns lowercased name without the leading slash.
-const tagNameOf = (rawTag: string): string => {
-  const trimmed = rawTag.trim();
-  const stripped = trimmed.startsWith('/') ? trimmed.slice(1) : trimmed;
-  const spaceOrSlash = stripped.search(/[\s/>]/);
-  return (spaceOrSlash < 0 ? stripped : stripped.slice(0, spaceOrSlash)).toLowerCase();
-};
-
-const HAS_HTML_TAG = /<\/?[a-zA-Z][^>]*>/;
-
-// Returns true if the input looks like HTML (contains at least one
-// well-formed-looking tag). Lets the popup short-circuit and skip the
-// converter for plain text.
-export const looksLikeHtml = (s: string): boolean => HAS_HTML_TAG.test(s);
+  finalize(): string {
+    // Per-line normalisation: preserve leading indent (so the
+    // numbered-list nesting "  1. item" survives), collapse
+    // INTERNAL whitespace runs to a single space, strip trailing
+    // whitespace, and drop empty lines so paragraph / list-section
+    // breaks don't render as visible blank rows.
+    const lines = this.out
+      .split('\n')
+      .map((line) => {
+        const match = line.match(/^([ \t]*)(.*)$/);
+        if (!match) {
+          return '';
+        }
+        const stripped = match[2].replace(/[ \t]+/g, ' ').trimEnd();
+        return stripped === '' ? '' : match[1] + stripped;
+      })
+      .filter((line) => line !== '');
+    return lines.join('\n');
+  }
+}
 
 export const htmlToPlainText = (html: string): string => {
+  // Fast path matches the v1.0.6 contract: pure plain text round-trips
+  // through unchanged.
   if (!looksLikeHtml(html) && html.indexOf('&') < 0) {
     return html;
   }
-  let out = '';
-  let i = 0;
-  while (i < html.length) {
-    const ch = html[i];
-    if (ch === '<') {
-      const end = html.indexOf('>', i);
-      if (end < 0) {
-        // Malformed: no closing '>'. Treat the rest as text rather
-        // than dropping it.
-        out += html.slice(i);
-        break;
-      }
-      const name = tagNameOf(html.slice(i + 1, end));
-      // Layout substitutions for the structural tags Wiktionary-style
-      // dicts use. Other tags (i, b, span, font, …) drop, content stays.
-      const isClose = html.slice(i + 1, end).trim().startsWith('/');
-      if (name === 'br') {
-        out += '\n';
-      } else if (name === 'li' && !isClose) {
-        // Opening <li>: introduce a bullet on its own line.
-        out += '\n• ';
-      } else if (name === 'p' && !isClose) {
-        // Opening <p>: paragraph break.
-        out += '\n\n';
-      } else if (name === 'div') {
-        // <div> is Wikdict's wrapper for translation lines AND the
-        // outer container for the whole entry. Treat it as a soft
-        // block boundary so `...sichtbar ist<div>astre</div>` no
-        // longer renders as the glued `istastre` (issue #15).
-        //
-        // Rule: insert a newline on open <div> unless we're already
-        // at the start of a line (or of the entry). Determining that
-        // means looking past any trailing inline whitespace at the
-        // last meaningful character:
-        //   - empty output       → at start of entry, skip (no leading blank)
-        //   - last non-space '\n' → at line start, skip
-        //   - last non-space '•' → inside an <li> bullet ("\n• "),
-        //                          skip so the bullet keeps its content
-        //   - anything else      → inside text content, INSERT '\n'
-        //                          (covers both the no-trailing-space
-        //                          Gestirn case and the trailing-space
-        //                          variant `…ist <div>astre</div>`,
-        //                          where space alone is not enough to
-        //                          un-glue the translation).
-        //
-        // Closing </div> always emits '\n' so adjacent <div> siblings
-        // in <ol>/<li> structures separate cleanly; the post-pass
-        // collapses any \n{2,} so this never produces double-blanks.
-        if (isClose) {
-          out += '\n';
-        } else {
-          // Walk back past any inline whitespace — including NBSP
-          // (U+00A0), which decodeEntity emits for `&nbsp;`. A
-          // future Wikdict shape with `…ist&nbsp;<div>astre</div>`
-          // would otherwise be treated as "still inside text" and
-          // glue translation onto the line. Treating NBSP as
-          // whitespace here keeps the discriminator robust.
-          let j = out.length - 1;
-          while (
-            j >= 0 &&
-            (out[j] === ' ' || out[j] === '\t' || out[j] === ' ')
-          ) {
-            j--;
-          }
-          if (j >= 0 && out[j] !== '\n' && out[j] !== '•') {
-            out += '\n';
-          }
-        }
-      }
-      // /li, /ol, /ul, ol, ul, /p, and all unknown tags: no output.
-      i = end + 1;
-    } else if (ch === '&') {
-      const semi = html.indexOf(';', i);
-      // Entity references are short. If we can't find a ';' within
-      // 20 chars, treat the '&' as literal. The limit covers long
-      // numeric entities (`&#1234567890;`) and verbose-but-reasonable
-      // named ones; anything longer is almost certainly not an entity.
-      if (semi < 0 || semi - i > 20) {
-        out += '&';
-        i++;
-      } else {
-        out += decodeEntity(html.slice(i + 1, semi));
-        i = semi + 1;
-      }
-    } else {
-      out += ch;
-      i++;
-    }
-  }
-  // Tidy: collapse runs of inline whitespace and any multi-newline
-  // sequence to a single newline. This produces tight output where
-  // each visible line is either a label, a bullet, or a paragraph —
-  // matching what users actually want for definition rendering. A
-  // <br> immediately followed by <li> shouldn't waste a blank line.
-  return out
-    .replace(/[ \t]+/g, ' ')
-    .replace(/ ?\n ?/g, '\n')
-    .replace(/\n{2,}/g, '\n')
-    .trim();
+  const renderer = new PlainTextRenderer();
+  parseHtml(html, renderer);
+  return renderer.finalize();
 };

--- a/src/ui/htmlToSpans.ts
+++ b/src/ui/htmlToSpans.ts
@@ -1,0 +1,291 @@
+// Rich-rendering consumer of the shared HTML renderer base.
+//
+// Produces an array of `Span` objects — each span carries its text
+// content plus the style (bold / italic / colour) that applies to
+// it. The React Native popup composes these into nested <Text>
+// elements (HtmlText.tsx), preserving the inline em-dash translation
+// shape AND emboldening translations and italicising part-of-speech
+// tags. Layout characters (newlines, indents, list markers, em-
+// dashes) are emitted as unstyled spans so a surrounding <i>POS</i>
+// scope can't accidentally italicise a list marker.
+//
+// The line-state, ol/ul nesting, and inline-vs-block <div> rules are
+// shared with htmlToPlainText via HtmlBaseRenderer — this file is
+// purely the span/style sink.
+
+import {parseHtml, looksLikeHtml} from './htmlParser';
+import {HtmlBaseRenderer, type StyleHint} from './htmlRenderBase';
+
+export type SpanStyle = {
+  bold?: boolean;
+  italic?: boolean;
+  // Empty string / undefined means "no colour hint". Truthy values
+  // are the raw `color="..."` attribute from the dict HTML and may
+  // contain anything (named colours, hex, malformed); the consumer
+  // is responsible for resolving + sanitising them at render time.
+  color?: string;
+};
+
+export type Span = {
+  text: string;
+  style: SpanStyle;
+};
+
+const EMPTY_STYLE: SpanStyle = Object.freeze({});
+
+// Style hints stack into a single effective style. Bold / italic
+// merge as logical OR (any active hint sets it). Colour stacks
+// last-wins (the innermost `<font color>` overrides the outer one).
+const mergeStyles = (stack: StyleHint[]): SpanStyle => {
+  if (stack.length === 0) {
+    return EMPTY_STYLE;
+  }
+  const merged: SpanStyle = {};
+  for (const hint of stack) {
+    if (hint.bold) {
+      merged.bold = true;
+    }
+    if (hint.italic) {
+      merged.italic = true;
+    }
+    if (hint.color !== undefined && hint.color !== '') {
+      merged.color = hint.color;
+    }
+  }
+  return merged;
+};
+
+const styleEquals = (a: SpanStyle, b: SpanStyle): boolean =>
+  Boolean(a.bold) === Boolean(b.bold) &&
+  Boolean(a.italic) === Boolean(b.italic) &&
+  (a.color ?? '') === (b.color ?? '');
+
+class SpanRenderer extends HtmlBaseRenderer {
+  private spans: Span[] = [];
+  private styleStack: StyleHint[] = [];
+  private currentStyle: SpanStyle = EMPTY_STYLE;
+
+  protected pushStyle(style: StyleHint): void {
+    this.styleStack.push(style);
+    this.currentStyle = mergeStyles(this.styleStack);
+  }
+
+  protected popStyle(): void {
+    this.styleStack.pop();
+    this.currentStyle = mergeStyles(this.styleStack);
+  }
+
+  protected emitText(text: string): void {
+    this.appendSpan(text, this.currentStyle);
+  }
+
+  protected emitLayout(text: string): void {
+    // Layout never carries surrounding bold / italic / colour. List
+    // markers, em-dashes, and indents must render in the popup's
+    // base style regardless of what scope they're inside.
+    this.appendSpan(text, EMPTY_STYLE);
+  }
+
+  protected trimTrailingInlineWhitespace(): void {
+    // Walk back through spans (last-emitted first), trimming
+    // trailing space / tab / NBSP from each. Stops at the first
+    // non-whitespace tail or once the stack empties. Coalescing
+    // upstream means we usually only inspect the last span.
+    while (this.spans.length > 0) {
+      const tail = this.spans[this.spans.length - 1];
+      let end = tail.text.length;
+      while (
+        end > 0 &&
+        (tail.text[end - 1] === ' ' ||
+          tail.text[end - 1] === '\t' ||
+          tail.text[end - 1] === ' ')
+      ) {
+        end--;
+      }
+      if (end === tail.text.length) {
+        return; // already non-whitespace at the tail
+      }
+      if (end === 0) {
+        this.spans.pop(); // entirely whitespace — drop the span
+        continue;
+      }
+      tail.text = tail.text.slice(0, end);
+      return;
+    }
+  }
+
+  finalize(): Span[] {
+    return this.normalise(this.spans);
+  }
+
+  // -- internals --
+
+  private appendSpan(text: string, style: SpanStyle): void {
+    if (text.length === 0) {
+      return;
+    }
+    // Coalesce same-style adjacent spans so downstream <Text> trees
+    // stay shallow. This is purely a perf / cleanliness optimisation;
+    // tests rely on coalesced output for stable assertions.
+    const last = this.spans[this.spans.length - 1];
+    if (last && styleEquals(last.style, style)) {
+      last.text += text;
+      return;
+    }
+    this.spans.push({text, style});
+  }
+
+  // Normalisation pass mirroring htmlToPlainText.finalize, applied
+  // to the concatenated span text but rebuilt as spans so styling
+  // is preserved. Per-line: preserve indent, collapse internal
+  // whitespace runs, strip trailing whitespace, drop empty lines.
+  private normalise(spans: Span[]): Span[] {
+    if (spans.length === 0) {
+      return spans;
+    }
+    // Step 1: walk the spans linearly and apply per-line shaping.
+    // We track the position relative to the current line so we can
+    // recognise the indent (leading spaces immediately following a
+    // newline) and pass it through verbatim, while collapsing
+    // mid-line whitespace runs. We also drop empty-line runs.
+    type LineBuffer = {indent: string; chunks: Span[]; hasContent: boolean};
+    const lines: LineBuffer[] = [{indent: '', chunks: [], hasContent: false}];
+    let atLineStart = true;
+    let lastWasSpace = false;
+
+    const startNewLine = (): void => {
+      lines.push({indent: '', chunks: [], hasContent: false});
+      atLineStart = true;
+      lastWasSpace = false;
+    };
+
+    const appendChunk = (text: string, style: SpanStyle): void => {
+      if (text.length === 0) {
+        return;
+      }
+      const line = lines[lines.length - 1];
+      const prev = line.chunks[line.chunks.length - 1];
+      if (prev && styleEquals(prev.style, style)) {
+        prev.text += text;
+      } else {
+        line.chunks.push({text, style});
+      }
+      if (text.trim().length > 0) {
+        line.hasContent = true;
+      }
+    };
+
+    for (const span of spans) {
+      let i = 0;
+      while (i < span.text.length) {
+        const ch = span.text[i];
+        if (ch === '\n') {
+          startNewLine();
+          i++;
+          continue;
+        }
+        if (atLineStart && (ch === ' ' || ch === '\t')) {
+          // Capture the leading indent verbatim (single contiguous
+          // run). The base class only emits indents in 2-space
+          // increments via emitListItemMarker, so the run length is
+          // bounded.
+          const start = i;
+          while (
+            i < span.text.length &&
+            (span.text[i] === ' ' || span.text[i] === '\t')
+          ) {
+            i++;
+          }
+          lines[lines.length - 1].indent += span.text.slice(start, i);
+          continue;
+        }
+        // Past the indent: collapse runs of whitespace within the
+        // line to a single space. lastWasSpace lets the collapse
+        // span across span boundaries (`<i>foo </i> <i>bar</i>` is
+        // two adjacent space-spans with different styles; only one
+        // emits).
+        if (ch === ' ' || ch === '\t') {
+          if (!lastWasSpace) {
+            appendChunk(' ', span.style);
+            lastWasSpace = true;
+          }
+          atLineStart = false;
+          i++;
+          continue;
+        }
+        atLineStart = false;
+        lastWasSpace = false;
+        // Find the next whitespace / newline boundary; emit the
+        // contiguous run as a single chunk in this span's style.
+        const start = i;
+        while (
+          i < span.text.length &&
+          span.text[i] !== '\n' &&
+          span.text[i] !== ' ' &&
+          span.text[i] !== '\t'
+        ) {
+          i++;
+        }
+        appendChunk(span.text.slice(start, i), span.style);
+      }
+    }
+
+    // Step 2: drop empty lines, strip per-line trailing whitespace,
+    // join with explicit \n layout spans.
+    const result: Span[] = [];
+    let appendNewline = false;
+    for (const line of lines) {
+      // Strip trailing whitespace within the line by walking back
+      // through chunks until we find one with non-whitespace.
+      while (line.chunks.length > 0) {
+        const tail = line.chunks[line.chunks.length - 1];
+        const trimmed = tail.text.replace(/[ \t]+$/, '');
+        if (trimmed.length === 0) {
+          line.chunks.pop();
+          continue;
+        }
+        if (trimmed !== tail.text) {
+          tail.text = trimmed;
+        }
+        break;
+      }
+      if (!line.hasContent) {
+        continue;
+      }
+      if (appendNewline) {
+        result.push({text: '\n', style: EMPTY_STYLE});
+      }
+      if (line.indent.length > 0) {
+        result.push({text: line.indent, style: EMPTY_STYLE});
+      }
+      for (const chunk of line.chunks) {
+        if (chunk.text.length === 0) {
+          continue;
+        }
+        // Coalesce with the previous result span if styles match.
+        const last = result[result.length - 1];
+        if (last && styleEquals(last.style, chunk.style)) {
+          last.text += chunk.text;
+        } else {
+          result.push(chunk);
+        }
+      }
+      appendNewline = true;
+    }
+    return result;
+  }
+}
+
+export const htmlToSpans = (html: string): Span[] => {
+  if (html.length === 0) {
+    return [];
+  }
+  // Fast path: pure plain text. One unstyled span. Avoids parser
+  // overhead for the common WordNet-fallback case.
+  if (!looksLikeHtml(html) && html.indexOf('&') < 0) {
+    return [{text: html, style: EMPTY_STYLE}];
+  }
+  const renderer = new SpanRenderer();
+  parseHtml(html, renderer);
+  return renderer.finalize();
+};


### PR DESCRIPTION
## Summary

- **Issue #19 (alioth9)** — formatting/rendering improvements for StarDict entries:
  - `<ol>` items now numbered (`1.`, `2.`, …) with 2-space indent per nesting level; `<ul>` keeps `•`.
  - Inline `<div>` translations (e.g. Wikdict's `body<div>tr</div>`) join with ` — ` per alioth9's follow-up on #15; sibling `<div>`s join with `, `.
  - Block-mode `<div>` (line-start) keeps the v1.0.8 un-glue behavior.
  - New rich React Native renderer (`HtmlText.tsx` / `htmlToSpans.ts`) bolds inline translations, italicises `<i>POS</i>`, applies `<font color>` from the dict.
- **Shared infra** (`htmlParser.ts` + `htmlRenderBase.ts`) — single tokenizer + layout state machine drives both plain-text and rich-span paths (DRY, single source of truth).
- **Release workflow** — adds two `workflow_dispatch` boolean inputs:
  - `prerelease` (default `false`) — flag the GitHub Release as pre-release.
  - `make_latest` (default `true`) — control whether the release becomes the repo's "Latest".

## Tests

- Unit (plain-text + spans): full snapshot of the issue #19 verbatim Himmel HTML, plus positive/negative assertions for sense numbering, depth-2 indent, sense-2 em-dash join, sense-3 nested numbered translations, and v1.0.6 / v1.0.8 glue regressions.
- Integration (release-gated): added `Himmel` to `wikdict-de-fr` manifest. Real `.dict` body asserted in CI. **6/6 real-StarDict tests pass** against actual downloads (Gestirn, Hund, Himmel, chien, maison, Buch).
- Coverage: 99.18% stmts / 97.21% branches / 98.35% funcs / 99.16% lines.
- Lint clean.

## Test plan

- [ ] Run `npm test` locally — 653 tests pass, 3 skipped.
- [ ] Run `npm run test:integration` — downloads + verifies all 6 entries against real Wikdict dicts.
- [ ] Manual sanity on a Supernote: lookup `Himmel` (de→fr), `Gestirn` (de→fr), `chien` (fr→de) — confirm em-dash join, numbered nesting, bold translations render correctly on e-ink.
- [ ] Test the new workflow inputs by triggering a dry-run release with `prerelease=true` / `make_latest=false`.

Closes #19.