### PR TITLE
feat(html): outline-style nested markers, 4-space indent, bold block-mode translations (issue #19)

### DIFF
--- a/__tests__/HtmlText.test.tsx
+++ b/__tests__/HtmlText.test.tsx
@@ -101,6 +101,56 @@ describe('HtmlText', () => {
     expect(style?.fontWeight).toBe('700');
   });
 
+  test('emboldens block-mode <div> translations inside an <li> at fontWeight 700 (issue #19)', () => {
+    // alioth9's follow-up on issue #19: `<li><div>chien</div></li>`
+    // sibling translations were body-weight in v1.0.9; v1.0.10
+    // bolds them to match the inline-mode case so single- and
+    // multi-translation entries read with the same visual weight.
+    const tree = render(
+      '<ol><li><div>chien</div></li><li><div>chienne</div></li></ol>',
+    );
+    const root = tree.toJSON() as unknown as RTNode;
+    const all = collectAllNodes(root);
+    const chienText = all.find(
+      (n) =>
+        n.type === 'Text' &&
+        n.children?.length === 1 &&
+        n.children[0] === 'chien',
+    );
+    const chienneText = all.find(
+      (n) =>
+        n.type === 'Text' &&
+        n.children?.length === 1 &&
+        n.children[0] === 'chienne',
+    );
+    expect(
+      (chienText?.props.style as {fontWeight?: string} | undefined)
+        ?.fontWeight,
+    ).toBe('700');
+    expect(
+      (chienneText?.props.style as {fontWeight?: string} | undefined)
+        ?.fontWeight,
+    ).toBe('700');
+  });
+
+  test('top-level <div> with no enclosing list stays at body weight (no bold)', () => {
+    // The outer Wikdict wrapper case: `<div>...</div>` around the
+    // whole entry must not pop in bold — only translations inside
+    // an active <li> are bolded.
+    const tree = render('<div>plain wrapper body</div>');
+    const root = tree.toJSON() as unknown as RTNode;
+    const all = collectAllNodes(root);
+    // No descendant <Text> carries fontWeight 700.
+    for (const node of all) {
+      if (node !== root && node.type === 'Text') {
+        const style = node.props.style as
+          | {fontWeight?: string}
+          | undefined;
+        expect(style?.fontWeight).not.toBe('700');
+      }
+    }
+  });
+
   test('italicises <i> content (POS labels) and does not italicise surrounding text', () => {
     const tree = render('a <i>POS</i> b');
     const root = tree.toJSON() as unknown as RTNode;

--- a/__tests__/htmlToPlainText.test.ts
+++ b/__tests__/htmlToPlainText.test.ts
@@ -47,20 +47,85 @@ describe('htmlToPlainText', () => {
     );
   });
 
-  test('indents nested <ol> items by 2 spaces per nesting level', () => {
+  test('indents nested <ol> items by 4 spaces and switches to alpha (a./b.) at depth 2', () => {
+    // alioth9's issue #19 follow-up: nested numbered lists were
+    // confusing because every depth read as "1. 2. 3." Switched to
+    // outline style (1. → a. → i.) so depth is visually obvious.
     const html =
       '<ol><li>outer one<ol><li>inner a</li><li>inner b</li></ol></li>' +
       '<li>outer two</li></ol>';
     expect(htmlToPlainText(html)).toBe(
-      '1. outer one\n  1. inner a\n  2. inner b\n2. outer two',
+      '1. outer one\n    a. inner a\n    b. inner b\n2. outer two',
     );
   });
 
-  test('mixed <ol> + <ul> nest each maintain their own marker style', () => {
+  test('depth-3 <ol> renders lowercase roman (i./ii./iii.) under depth-2 alpha', () => {
+    // Outline cycle: 1. → a. → i. Triple-deep nesting is rare in
+    // dict HTML but possible (e.g. compound entries with nested
+    // sense lists). Pin the marker rotation so a future change
+    // can't silently drift the cycle.
+    const html =
+      '<ol><li>L1<ol><li>L2<ol><li>L3a</li><li>L3b</li><li>L3c</li>' +
+      '<li>L3d</li></ol></li></ol></li></ol>';
+    expect(htmlToPlainText(html)).toBe(
+      '1. L1\n    a. L2\n        i. L3a\n        ii. L3b\n        iii. L3c\n        iv. L3d',
+    );
+  });
+
+  test('depth-4+ <ol> falls back to bullet (•) — pathological depth still readable', () => {
+    // Depth ≥4 is pathological in dict HTML; rather than introduce
+    // a fourth marker style (uppercase alpha?) the renderer falls
+    // back to bullets so deep nesting stays readable.
+    const html =
+      '<ol><li>L1<ol><li>L2<ol><li>L3<ol><li>L4a</li><li>L4b</li>' +
+      '</ol></li></ol></li></ol></li></ol>';
+    expect(htmlToPlainText(html)).toBe(
+      '1. L1\n    a. L2\n        i. L3\n            • L4a\n            • L4b',
+    );
+  });
+
+  test('alpha cycle wraps past 26 (z. → aa. → ab.) at depth 2', () => {
+    // Spreadsheet-style cycle covers >26 items at depth 2 without
+    // running off the alphabet. Real dicts never reach 27 sub-senses,
+    // but the wrap rule is part of the contract.
+    const items = Array.from({length: 28}, (_, i) => `<li>n${i + 1}</li>`).join('');
+    const html = `<ol><li>top<ol>${items}</ol></li></ol>`;
+    const out = htmlToPlainText(html);
+    expect(out).toContain('    a. n1');
+    expect(out).toContain('    z. n26');
+    expect(out).toContain('    aa. n27');
+    expect(out).toContain('    ab. n28');
+  });
+
+  test('roman markers extend past x. correctly (xi./xii./xiii./xiv./xix./xx.)', () => {
+    // Pin the descending-additive roman expansion so a 20-item
+    // depth-3 list reads cleanly.
+    const items = Array.from({length: 20}, (_, i) => `<li>r${i + 1}</li>`).join('');
+    const html = `<ol><li>L1<ol><li>L2<ol>${items}</ol></li></ol></li></ol>`;
+    const out = htmlToPlainText(html);
+    expect(out).toContain('        x. r10');
+    expect(out).toContain('        xi. r11');
+    expect(out).toContain('        xiii. r13');
+    expect(out).toContain('        xiv. r14');
+    expect(out).toContain('        xix. r19');
+    expect(out).toContain('        xx. r20');
+  });
+
+  test('mixed <ol> + <ul> nest each maintain their own marker style at the new indent', () => {
     const html =
       '<ol><li>numbered<ul><li>bullet a</li><li>bullet b</li></ul></li></ol>';
     expect(htmlToPlainText(html)).toBe(
-      '1. numbered\n  • bullet a\n  • bullet b',
+      '1. numbered\n    • bullet a\n    • bullet b',
+    );
+  });
+
+  test('<ul> stays bulleted at every depth — nested <ul> does not rotate marker', () => {
+    // Only <ol> rotates; <ul> at any depth is "•". Pin so a future
+    // marker-cycle change to <ol> doesn't accidentally apply to <ul>.
+    const html =
+      '<ul><li>top<ul><li>mid<ul><li>deep</li></ul></li></ul></li></ul>';
+    expect(htmlToPlainText(html)).toBe(
+      '• top\n    • mid\n        • deep',
     );
   });
 
@@ -75,9 +140,10 @@ describe('htmlToPlainText', () => {
     expect(out).toContain('1. A salutation; a greeting used for most purposes');
     expect(out).toContain('noun');
     // Nested under an outer <ol> opened just before <i>noun</i>: the
-    // inner <ol>'s items show at depth 2 (two-space indent).
+    // inner <ol>'s items show at depth 2 (4-space indent, alpha
+    // marker per the v1.0.10 outline cycle).
     expect(out).toContain(
-      '  1. greeting, salutation, an instance of the interjection namaste',
+      '    a. greeting, salutation, an instance of the interjection namaste',
     );
     // No tags leak through.
     expect(out).not.toMatch(/<\/?[a-z]/i);
@@ -239,11 +305,12 @@ describe('htmlToPlainText', () => {
       expect(out).not.toMatch(/ist astre/);
     });
 
-    test('multi-translation Wikdict <ol><li><div>...</div></li> shape numbers items and bullets are gone', () => {
+    test('multi-translation Wikdict <ol><li><div>...</div></li> shape uses depth-2 alpha markers', () => {
       // Real shape from wikdict-de-fr "Hund": two translations under
       // a nested <ol>. Each translation is the only content of its
-      // <li>, so each renders as a numbered item without an em-dash
-      // (block-mode div, line-start at the marker).
+      // <li>, so each renders as a depth-2 alpha item without an
+      // em-dash (block-mode div, line-start at the marker). v1.0.10:
+      // depth-2 markers are now `a./b./...`, not `1./2./...`.
       const wikdictHund =
         '<div><font color="green">noun, male</font><br><ol>' +
         '<li>Haustier, dessen Vorfahre der Wolf ist<ol>' +
@@ -252,16 +319,16 @@ describe('htmlToPlainText', () => {
         '</ol></li></ol></div>';
       const out = htmlToPlainText(wikdictHund);
       // Outer <li> still gets its number; inner <li>s get nested
-      // depth-2 numbering.
+      // depth-2 alpha markers at the 4-space indent.
       expect(out).toMatch(/^noun, male/);
       expect(out).toContain('1. Haustier, dessen Vorfahre der Wolf ist');
-      expect(out).toContain('  1. chien');
-      expect(out).toContain('  2. chienne');
+      expect(out).toContain('    a. chien');
+      expect(out).toContain('    b. chienne');
       // Pre-v1.0.7 glue: "istchien" must never appear.
       expect(out).not.toMatch(/istchien/);
-      // Nested numbered items on consecutive lines (no blank gap
+      // Nested alpha items on consecutive lines (no blank gap
       // between them after post-pass).
-      expect(out).toMatch(/ {2}1\. chien\n {2}2\. chienne/);
+      expect(out).toMatch(/ {4}a\. chien\n {4}b\. chienne/);
     });
 
     test('Himmel-style: <li>body<div>translation</div></li> joins inline', () => {
@@ -293,6 +360,7 @@ describe('htmlToPlainText', () => {
       // alioth9 acknowledged this is a file-level structural issue
       // and even OSS-Dict can't pair them. We pin the simple "marker
       // on its own line" output so behaviour is at least predictable.
+      // v1.0.10: nested <ol> uses alpha at depth 2 and 4-space indent.
       const html =
         '<ol>' +
         '<li><ol><li>inner one</li><li>inner two</li></ol></li>' +
@@ -300,8 +368,8 @@ describe('htmlToPlainText', () => {
         '</ol>';
       const out = htmlToPlainText(html);
       expect(out).toContain('1.');
-      expect(out).toContain('  1. inner one');
-      expect(out).toContain('  2. inner two');
+      expect(out).toContain('    a. inner one');
+      expect(out).toContain('    b. inner two');
       expect(out).toContain('2. second top — tr');
     });
   });
@@ -342,26 +410,27 @@ describe('htmlToPlainText', () => {
       expect(out).toMatch(/^\/ˈhɪml̩\/\nnoun, male\n/);
     });
 
-    test('top-level senses are numbered 1./2./3. and inner items indent at depth 2', () => {
+    test('top-level senses are numbered 1./2./3. and inner items use depth-2 alpha at 4-space indent', () => {
       const out = htmlToPlainText(himmelHtml);
       // alioth9 acknowledged the file structurally puts the two
       // sibling inner <ol>s under one outer <li>, so the outer
       // "1." appears on its own line — even OSS-Dict can't pair
       // them. We pin that predictable shape rather than fight it.
       expect(out).toContain('1.');
-      // Sense 1 inner items (German definitions).
-      expect(out).toContain('  1. Luftraum, Gewölbe über der Erde');
+      // Sense 1 inner items (German definitions). v1.0.10: depth-2
+      // alpha markers, 4-space indent (was "  1. …" in v1.0.9).
+      expect(out).toContain('    a. Luftraum, Gewölbe über der Erde');
       expect(out).toContain(
-        '  2. Religion: Aufenthaltsort im Jenseits mit Gott und den Engeln',
+        '    b. Religion: Aufenthaltsort im Jenseits mit Gott und den Engeln',
       );
       // Sense 1 inner translations (still as their own depth-2 list).
-      expect(out).toContain('  1. ciel');
-      expect(out).toContain('  2. paradis');
+      expect(out).toContain('    a. ciel');
+      expect(out).toContain('    b. paradis');
       // Sense 2: body + inline em-dash translation in one line.
       expect(out).toContain('2. Astronomie: der Kosmos — ciel');
-      // Sense 3: body line, then nested numbered translations.
+      // Sense 3: body line, then nested alpha-marker translations.
       expect(out).toContain('3. Decke aus Stoff oder ähnlichem Material');
-      expect(out).toMatch(/3\. Decke[^\n]*\n {2}1\. ciel\n {2}2\. dais/);
+      expect(out).toMatch(/3\. Decke[^\n]*\n {4}a\. ciel\n {4}b\. dais/);
     });
 
     test('does not emit any v1.0.6 / v1.0.8 glue regressions', () => {
@@ -382,19 +451,23 @@ describe('htmlToPlainText', () => {
       // display it. If a future change shifts whitespace or
       // numbering, this assertion fails with a one-character diff.
       // Update intentionally only in lockstep with a UX decision.
+      // v1.0.10 changes vs v1.0.9: depth-2 markers are alpha
+      // (a./b. instead of 1./2.), and the indent grew from 2 to 4
+      // spaces. The plain-text path doesn't carry bold; the popup
+      // (HtmlText / htmlToSpans) layers bold on the <div> content.
       expect(htmlToPlainText(himmelHtml)).toBe(
         [
           '/ˈhɪml̩/',
           'noun, male',
           '1.',
-          '  1. Luftraum, Gewölbe über der Erde',
-          '  2. Religion: Aufenthaltsort im Jenseits mit Gott und den Engeln, in den die Seligen nach ihrem Tode aufgenommen werden',
-          '  1. ciel',
-          '  2. paradis',
+          '    a. Luftraum, Gewölbe über der Erde',
+          '    b. Religion: Aufenthaltsort im Jenseits mit Gott und den Engeln, in den die Seligen nach ihrem Tode aufgenommen werden',
+          '    a. ciel',
+          '    b. paradis',
           '2. Astronomie: der Kosmos — ciel',
           '3. Decke aus Stoff oder ähnlichem Material',
-          '  1. ciel',
-          '  2. dais',
+          '    a. ciel',
+          '    b. dais',
         ].join('\n'),
       );
     });

--- a/__tests__/htmlToSpans.test.ts
+++ b/__tests__/htmlToSpans.test.ts
@@ -134,13 +134,44 @@ describe('htmlToSpans — list rendering matches plain-text shape', () => {
     expect(concatText(spans)).toBe('• first\n• second');
   });
 
-  test('nested <ol> under <ol> indents inner items by 2 spaces per depth', () => {
+  test('nested <ol> under <ol> uses 4-space indent and depth-2 alpha markers (v1.0.10)', () => {
     const html =
       '<ol><li>outer one<ol><li>inner a</li><li>inner b</li></ol></li>' +
       '<li>outer two</li></ol>';
     expect(concatText(htmlToSpans(html))).toBe(
-      '1. outer one\n  1. inner a\n  2. inner b\n2. outer two',
+      '1. outer one\n    a. inner a\n    b. inner b\n2. outer two',
     );
+  });
+
+  test('depth-3 <ol> under depth-2 alpha emits roman markers (i./ii./iii.)', () => {
+    const html =
+      '<ol><li>L1<ol><li>L2<ol><li>x</li><li>y</li><li>z</li></ol>' +
+      '</li></ol></li></ol>';
+    expect(concatText(htmlToSpans(html))).toBe(
+      '1. L1\n    a. L2\n        i. x\n        ii. y\n        iii. z',
+    );
+  });
+
+  test('depth-4 <ol> falls back to bullet (•) at 12-space indent', () => {
+    const html =
+      '<ol><li>1<ol><li>2<ol><li>3<ol><li>4</li></ol></li></ol>' +
+      '</li></ol></li></ol>';
+    expect(concatText(htmlToSpans(html))).toBe(
+      '1. 1\n    a. 2\n        i. 3\n            • 4',
+    );
+  });
+
+  test('list markers stay unstyled even when the marker style rotates (alpha / roman)', () => {
+    // Pin: depth rotation does NOT introduce styling on markers.
+    // Markers are layout regardless of which marker shape applies.
+    const html =
+      '<font color="green"><ol><li>L1<ol><li>L2<ol><li>L3</li></ol>' +
+      '</li></ol></li></ol></font>';
+    const spans = htmlToSpans(html);
+    const alphaMarker = spans.find((s) => s.text.includes('a.'));
+    const romanMarker = spans.find((s) => s.text.includes('i.'));
+    expect(alphaMarker?.style.color).toBeFalsy();
+    expect(romanMarker?.style.color).toBeFalsy();
   });
 });
 
@@ -182,16 +213,52 @@ describe('htmlToSpans — translation (<div>) emboldening', () => {
     expect(commaSpan?.style.bold).toBeFalsy();
   });
 
-  test('block-mode <div> (sole content of an <li>) does NOT bold', () => {
-    // When a <div> is the only content of its <li>, it renders in
-    // block mode (no em-dash). In that case the translation reads
-    // as an item body; emboldening would over-emphasise it. Per the
-    // base class rule, block-mode <div> pushes an empty style so
-    // the content stays at the popup's body weight.
+  test('block-mode <div> as sole content of an <li> IS bold (v1.0.10)', () => {
+    // Issue #19 follow-up from alioth9: previously the v1.0.9
+    // renderer left block-mode <div>s un-bold so single-translation
+    // entries (`Astronomie ... — ciel`) read in bold but multi-
+    // translation lists (`<li><div>ciel</div></li><li><div>paradis
+    // </div></li>`) read at body weight, which felt inconsistent.
+    // v1.0.10 unifies the two: any <div> opening inside a list item
+    // is treated as a translation and bolded.
     const spans = htmlToSpans('<ol><li><div>chien</div></li></ol>');
     expect(concatText(spans)).toBe('1. chien');
     const word = spans.find((s) => s.text === 'chien');
-    expect(word?.style.bold).toBeFalsy();
+    expect(word?.style.bold).toBe(true);
+  });
+
+  test('top-level <div>x</div> with no enclosing list stays UN-bold', () => {
+    // The outer-wrapper case: `<div>...whole entry...</div>` is the
+    // common Wikdict shape and must not pop in bold. Only block-mode
+    // <div>s INSIDE a list pick up the translation styling.
+    const spans = htmlToSpans('<div>plain wrapper body</div>');
+    const body = spans.find((s) => s.text.includes('plain wrapper body'));
+    expect(body?.style.bold).toBeFalsy();
+  });
+
+  test('multiple block-mode <div> siblings inside one <li> all bold', () => {
+    // `<li><div>x</div><div>y</div></li>` — first div is block-mode
+    // (no preceding content in this <li>); after its close the
+    // newline resets contentOnLine so the second div is also block-
+    // mode. Both are translations, both bold.
+    const spans = htmlToSpans(
+      '<ol><li><div>chien</div><div>poules</div></li></ol>',
+    );
+    const chien = spans.find((s) => s.text === 'chien');
+    const poules = spans.find((s) => s.text === 'poules');
+    expect(chien?.style.bold).toBe(true);
+    expect(poules?.style.bold).toBe(true);
+  });
+
+  test('block-mode <div> at depth 2 (under nested <ol>) is bold (Hund / Himmel pattern)', () => {
+    // The exact pattern from wikdict-de-fr Himmel sense 1 and Hund:
+    // outer <ol><li>body<ol><li><div>tr</div></li></ol></li></ol>.
+    // The inner div opens at depth 2 in block mode — bold.
+    const spans = htmlToSpans(
+      '<ol><li>body<ol><li><div>tr</div></li></ol></li></ol>',
+    );
+    const tr = spans.find((s) => s.text === 'tr');
+    expect(tr?.style.bold).toBe(true);
   });
 });
 
@@ -220,7 +287,7 @@ describe('htmlToSpans — full Wikdict + Wiktionary entry shape', () => {
     expect(translation?.style.bold).toBe(true);
   });
 
-  test('Hund-style nested <ol> with <div> translations: nested numbering, no bold (block-mode)', () => {
+  test('Hund-style nested <ol> with <div> translations: depth-2 alpha markers, both translations bold (v1.0.10)', () => {
     const wikdictHund =
       '<div><font color="green">noun, male</font><br><ol>' +
       '<li>Haustier, dessen Vorfahre der Wolf ist<ol>' +
@@ -229,13 +296,14 @@ describe('htmlToSpans — full Wikdict + Wiktionary entry shape', () => {
       '</ol></li></ol></div>';
     const spans = htmlToSpans(wikdictHund);
     expect(concatText(spans)).toBe(
-      'noun, male\n1. Haustier, dessen Vorfahre der Wolf ist\n  1. chien\n  2. chienne',
+      'noun, male\n1. Haustier, dessen Vorfahre der Wolf ist\n    a. chien\n    b. chienne',
     );
-    // chien / chienne are leaf <div>s but block-mode (sole content
-    // of their <li>) — so they are NOT bold. This matches the
-    // base-class rule and the plain-text path's expectation.
-    expect(spans.find((s) => s.text === 'chien')?.style.bold).toBeFalsy();
-    expect(spans.find((s) => s.text === 'chienne')?.style.bold).toBeFalsy();
+    // v1.0.10: chien / chienne are leaf <div>s in block-mode INSIDE
+    // a list — translations get bolded the same way inline-mode
+    // translations (`Astronomie — ciel`) are bolded. alioth9 in
+    // issue #19: "if possible it should be" bolded for consistency.
+    expect(spans.find((s) => s.text === 'chien')?.style.bold).toBe(true);
+    expect(spans.find((s) => s.text === 'chienne')?.style.bold).toBe(true);
     // POS still bears the green hint.
     expect(spans.find((s) => s.text === 'noun, male')?.style.color).toBe(
       'green',
@@ -276,10 +344,11 @@ describe('htmlToSpans — full Wikdict + Wiktionary entry shape', () => {
     // POS in green.
     const pos = spans.find((s) => s.text === 'noun, male');
     expect(pos?.style.color).toBe('green');
-    // Sense 2's inline-div translation is bold (it's the only
-    // truly inline-mode <div> in this entry — sense 1's `ciel`/
-    // `paradis` and sense 3's `ciel`/`dais` are sole children of
-    // their <li>s, so they render in block-mode and stay un-bold).
+    // v1.0.10: every translation in this entry is bold. Sense 2 is
+    // inline-mode (em-dash join), sense 1's `ciel`/`paradis` and
+    // sense 3's `ciel`/`dais` are block-mode <div>s inside <li>s —
+    // all four now bold to match alioth9's request that block-mode
+    // translations match the visual weight of inline ones.
     const senseTwo = spans.find(
       (s) =>
         s.text === 'ciel' &&
@@ -288,31 +357,32 @@ describe('htmlToSpans — full Wikdict + Wiktionary entry shape', () => {
         !s.style.italic,
     );
     expect(senseTwo).toBeDefined();
-    // Block-mode `dais` (sole content of its <li>) is NOT bold —
-    // pin so a future renderer change can't accidentally embolden
-    // every leaf <div>. The block-mode word coalesces into the
-    // surrounding unstyled layout chunk, so we assert via "any
-    // span containing 'dais' is not bold" rather than an exact
-    // text match.
+    // Block-mode `dais` (sole content of its <li>) is bold — the
+    // word coalesces into the same span as anything bold-and-
+    // unstyled-otherwise that immediately precedes it; assert via
+    // "any span containing 'dais' is bold".
     const daisCarriers = spans.filter((s) => s.text.includes('dais'));
     expect(daisCarriers.length).toBeGreaterThan(0);
-    for (const carrier of daisCarriers) {
-      expect(carrier.style.bold).toBeFalsy();
-    }
-    // Visible text matches the plain-text path snapshot.
+    expect(daisCarriers.some((c) => c.style.bold === true)).toBe(true);
+    // Sense 1's `paradis` (also block-mode under nested <ol>) bold.
+    const paradisCarriers = spans.filter((s) => s.text.includes('paradis'));
+    expect(paradisCarriers.length).toBeGreaterThan(0);
+    expect(paradisCarriers.some((c) => c.style.bold === true)).toBe(true);
+    // Visible text matches the plain-text path snapshot exactly
+    // (depth-2 alpha + 4-space indent per v1.0.10).
     expect(concatText(spans)).toBe(
       [
         '/ˈhɪml̩/',
         'noun, male',
         '1.',
-        '  1. Luftraum, Gewölbe über der Erde',
-        '  2. Religion: Aufenthaltsort im Jenseits mit Gott und den Engeln, in den die Seligen nach ihrem Tode aufgenommen werden',
-        '  1. ciel',
-        '  2. paradis',
+        '    a. Luftraum, Gewölbe über der Erde',
+        '    b. Religion: Aufenthaltsort im Jenseits mit Gott und den Engeln, in den die Seligen nach ihrem Tode aufgenommen werden',
+        '    a. ciel',
+        '    b. paradis',
         '2. Astronomie: der Kosmos — ciel',
         '3. Decke aus Stoff oder ähnlichem Material',
-        '  1. ciel',
-        '  2. dais',
+        '    a. ciel',
+        '    b. dais',
       ].join('\n'),
     );
   });

--- a/__tests__/integration/manifest.ts
+++ b/__tests__/integration/manifest.ts
@@ -85,26 +85,27 @@ export const MANIFEST: DictManifest[] = [
       {
         // Multi-translation entry under <ol><li><div>...</div></li>.
         // Each translation is the SOLE content of an inner <li>, so
-        // the renderer keeps them as numbered (block-mode) items
-        // rather than em-dash inline. v1.0.9 numbering replaces the
-        // v1.0.8 "• " bullets.
+        // the renderer keeps them as block-mode items rather than
+        // em-dash inline. v1.0.10: depth-2 markers are alpha
+        // (a./b./…) at 4-space indent, replacing v1.0.9's depth-2
+        // numeric and 2-space indent.
         word: 'Hund',
-        contains: ['noun, male', '1. chien', '2. chienne'],
+        contains: ['noun, male', 'a. chien', 'b. chienne'],
         // Pre-fix forms: "ist<div>chien" produced "istchien" type
-        // glue; the numbered items must never collapse into a
-        // single run of text.
-        notContains: ['istchien', 'chien2. chienne', '• chien'],
-        // Inner <ol> renders at depth 2 (two-space indent).
-        matches: [/ {2}1\. chien\n {2}2\. chienne/],
+        // glue; the alpha items must never collapse into a single
+        // run of text. v1.0.9 depth-2 numeric markers are gone.
+        notContains: ['istchien', 'chienb. chienne', '• chien', '  1. chien'],
+        // Inner <ol> renders at depth 2 (4-space indent, alpha).
+        matches: [/ {4}a\. chien\n {4}b\. chienne/],
       },
       {
-        // Issue #19's worked example. Mixes all three v1.0.9 cases
+        // Issue #19's worked example. Mixes all three v1.0.10 cases
         // in one entry:
         //   - sense 2 has a `body<div>tr</div>` inline em-dash join,
         //   - sense 1 has a sibling `<ol>` of pure-<div> translations
-        //     (block-mode numbered items at depth 2),
-        //   - sense 3 has a body line followed by a nested numbered
-        //     list of translations.
+        //     (block-mode alpha-marker items at depth 2, all bold),
+        //   - sense 3 has a body line followed by a nested alpha
+        //     list of translations (also block-mode bold).
         // Single integration entry covering the whole shape so a
         // future renderer change against the real .dict body is a
         // visible failure here.
@@ -116,24 +117,28 @@ export const MANIFEST: DictManifest[] = [
           'Religion:', // sense 1 inner item 2
           'Astronomie: der Kosmos — ciel', // sense 2 inline em-dash
           'Decke aus Stoff', // sense 3 body
-          '  1. ciel',
-          '  2. dais',
+          '    a. ciel',
+          '    b. dais',
         ],
         notContains: [
           // No glue across the inline-translation boundary.
           'Kosmosciel',
           // No v1.0.8 newline-only shape for the inline case.
           'Kosmos\nciel',
-          // Bullets are gone in v1.0.9.
+          // Bullets at depth ≤3 are gone (v1.0.9 dropped them; v1.0.10
+          // kept that property — bullets only fire at depth ≥4).
           '• ciel',
           '• dais',
+          // v1.0.9 depth-2 numeric markers must not appear either.
+          '  1. ciel',
+          '  2. dais',
         ],
         matches: [
           // Sense 2 em-dash join.
           /Astronomie: der Kosmos\s+—\s+ciel/,
-          // Sense 3 body followed immediately by depth-2 numbered
+          // Sense 3 body followed immediately by depth-2 alpha-marker
           // translations (no blank line, no fall-through bullet).
-          /Decke aus Stoff[^\n]*\n {2}1\. ciel\n {2}2\. dais/,
+          /Decke aus Stoff[^\n]*\n {4}a\. ciel\n {4}b\. dais/,
         ],
       },
     ],
@@ -175,11 +180,19 @@ export const MANIFEST: DictManifest[] = [
     entries: [
       {
         word: 'Buch',
-        // v1.0.9: translations under nested <ol><li><div>book</div></li>
-        // render as numbered items at depth 2 (block-mode div).
+        // v1.0.10: translations under nested <ol><li><div>book</div></li>
+        // render as block-mode alpha items at depth 2 (4-space indent).
         contains: ['buːx', 'noun, neutral', 'Schriftwerk', 'book'],
-        notContains: ['Blattgold<', 'Blattgoldbook', '• book'],
-        matches: [/ {2}\d+\. book/],
+        notContains: [
+          'Blattgold<',
+          'Blattgoldbook',
+          '• book',
+          // v1.0.9 depth-2 numeric form must not reappear.
+          '  1. book',
+        ],
+        // Depth-2 alpha marker, 4-space indent. The first translation
+        // at depth 2 is `a.`; further siblings climb the alphabet.
+        matches: [/ {4}[a-z]+\. book/],
       },
     ],
   },

--- a/src/ui/htmlRenderBase.ts
+++ b/src/ui/htmlRenderBase.ts
@@ -19,8 +19,97 @@
 // to maintain a style stack. The base class always pairs a push
 // with a pop on every <div> open/close so style-stack subclasses
 // stay balanced even when div-mode swaps from inline to block.
+//
+// List-marker scheme (per alioth9's request in issue #19): nested
+// <ol> levels rotate through styles to make depth visually obvious
+// rather than repeating "1. 2. 3." at every level. The classic
+// outline cycle (decimal → lowercase alpha → lowercase roman →
+// bullet for anything deeper) is what readers expect from English
+// and French long-form documents and matches one of alioth9's
+// listed options (`a. b. c.`). <ul> stays as bullets at every depth.
 
 import {type HtmlVisitor, type TagInfo} from './htmlParser';
+
+// 4-space indent per nesting level. alioth9 asked for "more than 2"
+// in issue #19 and 4 is the de-facto standard for nested outlines
+// in academic prose (and what OSS-Dict's reference rendering uses).
+const INDENT_PER_DEPTH = '    ';
+
+// Lowercase roman numeral table, descending so a single linear pass
+// over the table emits the canonical compact form (4 → "iv", not
+// "iiii"). The 1000-cap is generous; dictionary list depth-3 entries
+// in practice cap out below 20.
+const ROMAN_NUMERALS: ReadonlyArray<readonly [number, string]> = [
+  [1000, 'm'],
+  [900, 'cm'],
+  [500, 'd'],
+  [400, 'cd'],
+  [100, 'c'],
+  [90, 'xc'],
+  [50, 'l'],
+  [40, 'xl'],
+  [10, 'x'],
+  [9, 'ix'],
+  [5, 'v'],
+  [4, 'iv'],
+  [1, 'i'],
+];
+
+// Counter is always ≥ 1 by the time we reach here (incremented in
+// emitListItemMarker before lookup), so no n≤0 guard is needed.
+const toRomanLower = (n: number): string => {
+  let remaining = n;
+  let out = '';
+  for (const [val, sym] of ROMAN_NUMERALS) {
+    while (remaining >= val) {
+      out += sym;
+      remaining -= val;
+    }
+  }
+  return out;
+};
+
+// Spreadsheet-style alpha: 1→'a', 26→'z', 27→'aa', 28→'ab', …
+// Wraps cleanly past 26 so a 30-item depth-2 list still renders
+// (`aa. ab. ac. ad.`) instead of running off the end of the alphabet.
+const toAlphaLower = (n: number): string => {
+  let remaining = n;
+  let out = '';
+  while (remaining > 0) {
+    remaining--;
+    out = String.fromCharCode(97 + (remaining % 26)) + out;
+    remaining = Math.floor(remaining / 26);
+  }
+  return out;
+};
+
+// Marker text (without trailing space) for an <ol>/<ul> item at the
+// given 1-based depth. <ul> is always bulleted. <ol> rotates:
+//   depth 1 → decimal      (1. 2. 3.)
+//   depth 2 → lowercase α  (a. b. c.)
+//   depth 3 → lowercase roman (i. ii. iii.)
+//   depth ≥ 4 → bullet     (•) — pathological depths fall back to
+//                                a marker the reader can't confuse
+//                                with another numbered level.
+const formatListMarker = (
+  kind: 'ol' | 'ul',
+  counter: number,
+  depth: number,
+): string => {
+  if (kind === 'ul') {
+    return '•';
+  }
+  if (depth <= 1) {
+    return `${counter}.`;
+  }
+  if (depth === 2) {
+    return `${toAlphaLower(counter)}.`;
+  }
+  if (depth === 3) {
+    return `${toRomanLower(counter)}.`;
+  }
+  return '•';
+};
 
 export type ListFrame = {
   // Whether items are numbered (ol) or bulleted (ul). A stray <li>
@@ -184,11 +273,11 @@ export abstract class HtmlBaseRenderer implements HtmlVisitor {
   protected emitListItemMarker(): void {
     const top = this.listStack[this.listStack.length - 1];
     const depth = this.listStack.length;
-    const indent = '  '.repeat(Math.max(0, depth - 1));
+    const indent = INDENT_PER_DEPTH.repeat(Math.max(0, depth - 1));
     if (top) {
       top.counter++;
-      const marker = top.kind === 'ol' ? `${top.counter}. ` : '• ';
-      this.emitLayout(`\n${indent}${marker}`);
+      const marker = formatListMarker(top.kind, top.counter, depth);
+      this.emitLayout(`\n${indent}${marker} `);
     } else {
       // <li> outside any list. Bullet at depth 0.
       this.emitLayout('\n• ');
@@ -209,9 +298,20 @@ export abstract class HtmlBaseRenderer implements HtmlVisitor {
       this.pushStyle({bold: true});
     } else {
       this.inlineDivStack.push(false);
-      // Block-mode <div>: push an empty style so the matching
-      // popStyle on close stays balanced regardless of mode.
-      this.pushStyle({});
+      // Block-mode <div> inside an active list (i.e. a translation
+      // sitting as the body of an <li>, like wikdict-de-fr's
+      // `<li><div>chien</div></li>` shape) is bolded too — alioth9
+      // flagged in issue #19 that single-line `<div>` translations
+      // were bolded but the same word inside a multi-translation
+      // <li><div>...</div> sibling list was not, and the
+      // inconsistency hurt readability. Top-level wrapper <div>
+      // (no enclosing list) keeps the empty style hint so it
+      // doesn't visually pop above the body text.
+      if (this.listStack.length > 0) {
+        this.pushStyle({bold: true});
+      } else {
+        this.pushStyle({});
+      }
     }
   }
 

--- a/src/ui/htmlToPlainText.ts
+++ b/src/ui/htmlToPlainText.ts
@@ -47,7 +47,7 @@ class PlainTextRenderer extends HtmlBaseRenderer {
 
   finalize(): string {
     // Per-line normalisation: preserve leading indent (so the
-    // numbered-list nesting "  1. item" survives), collapse
+    // numbered-list nesting "    a. item" survives), collapse
     // INTERNAL whitespace runs to a single space, strip trailing
     // whitespace, and drop empty lines so paragraph / list-section
     // breaks don't render as visible blank rows.

--- a/src/ui/htmlToSpans.ts
+++ b/src/ui/htmlToSpans.ts
@@ -186,9 +186,9 @@ class SpanRenderer extends HtmlBaseRenderer {
         }
         if (atLineStart && (ch === ' ' || ch === '\t')) {
           // Capture the leading indent verbatim (single contiguous
-          // run). The base class only emits indents in 2-space
-          // increments via emitListItemMarker, so the run length is
-          // bounded.
+          // run). The base class only emits indents in fixed-width
+          // increments (4 spaces per nesting depth) via
+          // emitListItemMarker, so the run length is bounded.
           const start = i;
           while (
             i < span.text.length &&


### PR DESCRIPTION
## Summary

Addresses the three remaining v1.0.9 follow-ups alioth9 raised on issue #19:

1. **Nested marker rotation.** `<ol>` no longer reads `1. 2. 3.` at every depth. Markers now cycle through the classic outline style:
   - depth 1 → decimal (`1. 2. 3.`)
   - depth 2 → lowercase alpha (`a. b. c. … z. aa. ab.`)
   - depth 3 → lowercase roman (`i. ii. iii. … xix. xx.`)
   - depth 4+ → bullet (`•`) — pathological depth still readable
   - `<ul>` keeps `•` at every depth.
2. **Indent grew from 2 → 4 spaces** per nesting level.
3. **Block-mode `<div>` translations inside an `<li>`** (the `<li><div>chien</div></li>` wikdict-de-fr shape) now render bold, matching the visual weight of inline-mode translations (`Astronomie ... — ciel`). Top-level wrapper `<div>` with no enclosing list stays unbold so the outer Wikdict wrapper doesn't pop above the body text.

All three rules live in `htmlRenderBase.ts` so the plain-text and span renderers stay in lockstep — no behavioral drift between `htmlToPlainText` and `htmlToSpans`.

## Test plan

- [ ] `npm run lint` passes
- [ ] `npm test` — 666 tests pass, coverage 99.18% lines / 97.23% branches / 98.37% functions (above the 97% threshold from `CLAUDE.md`)
- [ ] New unit tests cover marker rotation (decimal → alpha → roman → bullet), alpha cycle past `z.` (→ `aa. ab.`), roman past `x.` (→ `xi. xiii. xix. xx.`), and `<ul>` staying bulleted at every depth.
- [ ] New tests for block-mode bold against real Wikdict shapes (Hund, Himmel, Buch) plus the top-level-wrapper-stays-unbold case.
- [ ] React Native render-tree (`HtmlText.test.tsx`) explicitly asserts `fontWeight: '700'` on `<Text>` wrappers for block-mode translations and verifies the wrapper-`<div>` case stays at body weight.
- [ ] Integration manifest pins for wikdict-de-fr Hund/Himmel and wikdict-de-en Buch updated; v1.0.9 numeric depth-2 forms (`  1. chien`, `  1. ciel`, `  1. book`) added to `notContains` so a regression to the prior shape fails loudly.
- [ ] Verbatim Himmel HTML snapshot in `htmlToPlainText.test.ts` and `htmlToSpans.test.ts` updated to the new outline shape.

Closes the v1.0.9 follow-ups in #19.