### PR TITLE
fix(export): drop the two-"Close"-button modal; inline result banner

### DIFF
--- a/__tests__/DefinitionPopup.test.tsx
+++ b/__tests__/DefinitionPopup.test.tsx
@@ -1674,29 +1674,25 @@ describe('DefinitionPopup — dictionary manager (F3)', () => {
 
   test('Save is disabled until an edit, enabled after, and confirms INLINE (no modal)', async () => {
     const spy = jest.fn(async (_prefs: DictPref[]) => undefined);
-    // notify must NOT be used for the save acknowledgement — the old code reused
-    // the two-button confirm dialog as a notification (two "Close" buttons).
-    const notify = jest.fn(async () => undefined);
-    setPopupActions({
-      ...dictManagerActions(
+    setPopupActions(
+      dictManagerActions(
         [dictPref('User', true, 0), dictPref('WordNet', true, 1)],
         spy,
       ),
-      notify,
-    });
+    );
     const tree = renderPopup();
     await openSettings(tree);
     // No edits yet -> Save is disabled (a tap is a no-op, nothing persisted).
     await act(async () => findByLabel(tree, 'Save')[0].props.onPress());
     expect(spy).not.toHaveBeenCalled();
     expect(collectText(tree)).not.toContain('Settings saved');
-    // Edit -> Save now persists + confirms inline.
+    // Edit -> Save now persists + confirms inline (NOT via a modal dialog —
+    // the old code reused the two-button confirm, showing two "Close" buttons).
     await act(async () => findByLabel(tree, 'Disable: User')[0].props.onPress());
     await act(async () => findByLabel(tree, 'Save')[0].props.onPress());
     expect(spy).toHaveBeenCalledTimes(1);
-    // Inline acknowledgement, NOT a modal dialog.
+    // Inline acknowledgement.
     expect(collectText(tree)).toContain('Settings saved');
-    expect(notify).not.toHaveBeenCalled();
     // After a successful save the panel is clean -> Save no-ops again.
     await act(async () => findByLabel(tree, 'Save')[0].props.onPress());
     expect(spy).toHaveBeenCalledTimes(1);
@@ -1709,21 +1705,18 @@ describe('DefinitionPopup — dictionary manager (F3)', () => {
     const spy = jest.fn(async (_prefs: DictPref[]) => {
       throw new Error('disk full');
     });
-    const notify = jest.fn(async () => undefined);
-    setPopupActions({
-      ...dictManagerActions(
+    setPopupActions(
+      dictManagerActions(
         [dictPref('User', true, 0), dictPref('WordNet', true, 1)],
         spy,
       ),
-      notify,
-    });
+    );
     const tree = renderPopup();
     await openSettings(tree);
     await act(async () => findByLabel(tree, 'Disable: User')[0].props.onPress());
     await act(async () => findByLabel(tree, 'Save')[0].props.onPress());
     expect(spy).toHaveBeenCalledTimes(1);
     expect(collectText(tree)).toContain("Couldn't save settings");
-    expect(notify).not.toHaveBeenCalled();
     // Still dirty after the failure -> a retry Save fires again.
     await act(async () => findByLabel(tree, 'Save')[0].props.onPress());
     expect(spy).toHaveBeenCalledTimes(2);
@@ -2286,7 +2279,6 @@ const exportActions = (
       {label: 'WordNet', filename: 'base.db'},
       {label: 'User', filename: 'user.db'},
     ] as DbFile[],
-  notify: PopupActions['notify'] = async () => undefined,
 ): PopupActions => ({
   lookupThesaurus: async () => ({lang: 'en', omw: {synonyms: [], antonyms: []}}),
   addUserEntry: async () => undefined,
@@ -2299,7 +2291,6 @@ const exportActions = (
   listFolders,
   createFolder,
   exportDbs,
-  notify,
 });
 
 describe('DefinitionPopup — DB export (F5)', () => {
@@ -2354,22 +2345,25 @@ describe('DefinitionPopup — DB export (F5)', () => {
     expect(text).toContain(MYSTYLE);
   });
 
-  test('the export result is ALSO surfaced via notify (a modal the user cannot miss)', async () => {
-    const notifySpy = jest.fn(async () => undefined);
-    setPopupActions(
-      exportActions(undefined, undefined, undefined, undefined, notifySpy),
-    );
+  test('the export result is surfaced as a prominent inline alert banner (no modal)', async () => {
+    setPopupActions(exportActions());
     const tree = renderPopup();
     await openSettings(tree);
     await act(async () => {
       findByLabel(tree, 'Export dictionaries')[0].props.onPress();
       await flush();
     });
-    // The same result string handed to the inline summary is also pushed to
-    // the dialog — so a successful export can't look like nothing happened.
-    expect(notifySpy).toHaveBeenCalledWith(
-      expect.stringContaining('Export complete'),
+    // The result renders inline with role=alert (the can't-miss banner that
+    // replaced the two-"Close"-button modal) — there is no notify/dialog port.
+    const alerts = tree.root.findAll(
+      n => n.props.accessibilityRole === 'alert',
     );
+    const alertText = alerts
+      .map(n => (Array.isArray(n.props.children)
+        ? n.props.children.join('')
+        : String(n.props.children)))
+      .join(' | ');
+    expect(alertText).toContain('Export complete');
   });
 
   test('a partial-failure summary lists the failed file (F5-AC4)', async () => {

--- a/index.js
+++ b/index.js
@@ -531,16 +531,10 @@ bootstrap(bootstrapPorts, logger)
           },
           logger,
         ),
-      // Surface export/restore outcomes as a modal dialog (RattaDialog) — a
-      // result the user can't miss, unlike the inline summary that's easy to
-      // scroll past. Both buttons just dismiss it.
-      notify: msg =>
-        NativeUIUtils.showRattaDialog(
-          msg,
-          t('popup.close'),
-          t('popup.close'),
-          true,
-        ).then(() => undefined),
+      // No `notify` port: export/restore outcomes surface as the inline banner
+      // ExportSection renders. The native showRattaDialog is a TWO-button
+      // confirm, so using it for a one-action acknowledgement showed two
+      // identical "Close" buttons — the inline banner is the right surface.
     });
 
     logger.log(

--- a/src/ui/ExportSection.tsx
+++ b/src/ui/ExportSection.tsx
@@ -130,13 +130,14 @@ export default function ExportSection(props: {
       });
   };
 
-  // Show a result BOTH inline (persistent) AND as a modal dialog (notify) so
-  // the user can't miss it — an inline summary at the bottom of a scrolled
-  // panel was easy to overlook (the export looked dead though it had run). The
-  // dialog is best-effort (a missing notify port just leaves the inline text).
+  // Show the export/restore result inline, as a prominent bordered banner
+  // directly below the action buttons the user just tapped. This used to ALSO
+  // fire a modal (`notify`), but the only native dialog is the two-button
+  // confirm — so a one-action acknowledgement surfaced TWO identical "Close"
+  // buttons. Dropped: the banner (accessibilityRole="alert", right under the
+  // buttons) is the can't-miss surface, matching the inline Save status.
   const report = (msg: string): void => {
     setSummary(msg);
-    actions?.notify?.(msg).catch(() => {});
   };
 
   // Export every DB into the current folder. exportDbs orchestrates the
@@ -281,7 +282,7 @@ export default function ExportSection(props: {
       </View>
 
       {summary !== null ? (
-        <Text accessibilityRole="text" style={styles.exportSummary}>
+        <Text accessibilityRole="alert" style={styles.exportSummary}>
           {summary}
         </Text>
       ) : null}

--- a/src/ui/popupController.ts
+++ b/src/ui/popupController.ts
@@ -122,10 +122,11 @@ export type PopupActions = {
   // wired engine) still satisfy PopupActions; the panel guards on presence.
   confirmRestore?(): Promise<boolean>;
   restoreDbs?(backupDir: string): Promise<RestoreSummary>;
-  // Show a result/notification to the user as a modal dialog (the native
-  // RattaDialog). Used by export/restore to surface their outcome — an inline
-  // summary line at the bottom of a scrolled panel is too easy to miss.
-  notify?(message: string): Promise<void>;
+  // (No `notify` port: the only native dialog is the two-button confirm, so a
+  // one-action acknowledgement showed two identical "Close" buttons. Results
+  // are surfaced inline instead — the Save status and the export/restore
+  // banner. Genuine two-choice confirmations use confirmDeleteDict /
+  // confirmRestore.)
 };
 
 let popupActions: PopupActions | null = null;

--- a/src/ui/popupStyles.ts
+++ b/src/ui/popupStyles.ts
@@ -468,11 +468,20 @@ export const popupStyles = StyleSheet.create({
     fontSize: 14,
     color: '#000000',
   },
-  // The post-export result summary line.
+  // The post-export/restore result — a prominent bordered banner directly
+  // below the action buttons (the can't-miss surface now that the modal is
+  // gone). Bold black text in a boxed surface so a result can't be mistaken
+  // for body chrome on a scrolled e-ink panel.
   exportSummary: {
     marginTop: 12,
-    fontSize: 14,
+    fontSize: 15,
+    fontWeight: '700',
     color: '#000000',
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderWidth: 1.5,
+    borderColor: '#000000',
+    borderRadius: 4,
   },
   // Body-text size selector: three circular elements in a row,
   // ( − )( A )( + ). The outer two are Pressables; the middle is a


### PR DESCRIPTION
Follow-up to #29 (the fix landed on the branch after #29's merge snapshot, so it was stranded).

## Problem
The export/restore result was shown via a `notify` modal that reused the native **two-button** `showRattaDialog` for a one-action acknowledgement — so a successful export popped a dialog with **two identical "Close" buttons** (the same misuse already fixed for the Save confirmation). There is no single-button native dialog for arbitrary text.

## Fix
- Removed the `notify` port entirely (it was now unused) from `PopupActions` and `index.js`.
- Export/restore results surface **only inline**, as a prominent bordered banner with `role="alert"` directly under the action buttons — the can't-miss surface the modal was added for, consistent with the inline Save status.
- Genuine two-choice confirmations (Remove dict, Restore-overwrite) keep their real two-button dialogs.
- Tests: the export test now asserts the inline alert banner instead of a `notify` call; the Save tests drop their now-removed `notify` references.

## Verification
1,118 tests / 58 suites pass; lint clean (0 errors); coverage 99.45%.