### PR TITLE
fix(stardict): strip per-entry type byte when .ifo omits sametypesequence (#28)

### DIFF
--- a/__tests__/buildBaseDb.test.ts
+++ b/__tests__/buildBaseDb.test.ts
@@ -56,6 +56,42 @@ describe('entriesFromParsedDict', () => {
       expect(row.definition).toBe(lookupDict(parsed, row.word)?.definition);
     }
   });
+
+  // Regression byte-equality guard (issue #28): the sametypesequence
+  // split must NOT shift the body for sts-PRESENT dicts. base.db is
+  // built from WordNet, which sets sametypesequence=m, so persisted
+  // bodies must remain byte-identical to the raw payload for both the
+  // common 'm' (plain) and 'h' (html) single-char sts values.
+  it.each(['m', 'h'])(
+    'sts-present (=%s): persisted definitions equal the raw payload (no prefix/NUL shift)',
+    async sts => {
+      const t = buildSyntheticStarDict(DEFS, {sametypesequence: sts});
+      const parsed = await buildDict(t.ifo, t.idx, t.dict);
+      const rows = entriesFromParsedDict(parsed);
+      const byKey = new Map(rows.map(r => [r.key, r.definition]));
+      // The raw payload IS the definition verbatim when sts is present.
+      expect(byKey.get('apple')).toBe('a round fruit');
+      expect(byKey.get('banana')).toBe('a long yellow fruit');
+      expect(byKey.get("muad'dib")).toBe('a desert mouse');
+      // And it stays equal to what lookupDict returns.
+      for (const row of rows) {
+        expect(row.definition).toBe(lookupDict(parsed, row.word)?.definition);
+      }
+    },
+  );
+
+  it('sts-absent dict: persisted body == looked-up body (prefix/NUL stripped)', async () => {
+    const t = buildSyntheticStarDict(DEFS, {omitSametypesequence: true});
+    const parsed = await buildDict(t.ifo, t.idx, t.dict);
+    for (const row of entriesFromParsedDict(parsed)) {
+      expect(row.definition).toBe(lookupDict(parsed, row.word)?.definition);
+    }
+    const byKey = new Map(
+      entriesFromParsedDict(parsed).map(r => [r.key, r.definition]),
+    );
+    // No leading type byte, no trailing NUL leaked into the stored body.
+    expect(byKey.get('apple')).toBe('a round fruit');
+  });
 });
 
 describe('deterministicBuiltAt', () => {

--- a/__tests__/dictEntry.test.ts
+++ b/__tests__/dictEntry.test.ts
@@ -1,0 +1,108 @@
+// Unit table for the StarDict .dict entry splitter (issue #28). When a
+// dict declares sametypesequence, an entry's .dict bytes ARE the raw
+// payload. When it does NOT, each entry is `<type-char-byte><payload>`
+// optionally followed by a single 0x00 terminator — that prefix/trailer
+// is metadata and must be stripped before the body is decoded, else a
+// stray 'm'/'h' char and a NUL leak into every definition. The Kotlin
+// importer mirrors this helper byte-for-byte (device-only-bug guard).
+
+import {
+  splitDictEntry,
+  formatFromTypeChar,
+} from '../src/core/dict/stardict/dictEntry';
+
+const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+const dec = (b: Uint8Array): string => new TextDecoder().decode(b);
+
+describe('splitDictEntry', () => {
+  test('sametypesequence PRESENT: whole slice is the payload, no type char', () => {
+    const raw = enc('a fruit');
+    const {payload, typeChar} = splitDictEntry('m', raw);
+    expect(dec(payload)).toBe('a fruit');
+    expect(typeChar).toBeNull();
+  });
+
+  test('sametypesequence PRESENT preserves a leading char that is NOT a type prefix', () => {
+    // With sts present there is no per-entry prefix, so a body that
+    // happens to start with 'm' must survive intact.
+    const raw = enc('marble: a stone');
+    const {payload} = splitDictEntry('m', raw);
+    expect(dec(payload)).toBe('marble: a stone');
+  });
+
+  // CASE A: present, single char sts (the WordNet/base.db path).
+  test('CASE A: single-char sts present -> payload == whole slice', () => {
+    const raw = enc('definition body');
+    expect(dec(splitDictEntry('m', raw).payload)).toBe('definition body');
+  });
+
+  // CASE B: absent sts -> strip leading type byte (+ one trailing NUL).
+  test('CASE B: sts absent WITH trailing NUL -> strip type byte + one NUL', () => {
+    const raw = new Uint8Array([...enc('m'), ...enc('a fruit'), 0x00]);
+    const {payload, typeChar} = splitDictEntry(null, raw);
+    expect(dec(payload)).toBe('a fruit');
+    expect(typeChar).toBe('m');
+  });
+
+  test('CASE B: sts absent WITHOUT trailing NUL (last entry) -> strip type byte only', () => {
+    const raw = new Uint8Array([...enc('h'), ...enc('<b>x</b>')]);
+    const {payload, typeChar} = splitDictEntry(null, raw);
+    expect(dec(payload)).toBe('<b>x</b>');
+    expect(typeChar).toBe('h');
+  });
+
+  test('CASE B: strips EXACTLY ONE trailing NUL, leaving any earlier NUL intact', () => {
+    const raw = new Uint8Array([...enc('m'), ...enc('a'), 0x00, 0x00]);
+    const {payload} = splitDictEntry(null, raw);
+    // One trailing NUL stripped; the inner NUL stays.
+    expect(Array.from(payload)).toEqual([...enc('a'), 0x00]);
+  });
+
+  test('empty slice -> {empty payload, null typeChar} (no indexing crash)', () => {
+    const {payload, typeChar} = splitDictEntry(null, new Uint8Array(0));
+    expect(payload.length).toBe(0);
+    expect(typeChar).toBeNull();
+  });
+
+  test('empty slice with sts present -> {empty payload, null typeChar}', () => {
+    const {payload, typeChar} = splitDictEntry('m', new Uint8Array(0));
+    expect(payload.length).toBe(0);
+    expect(typeChar).toBeNull();
+  });
+
+  // CASE C: multi-char sts is out of scope for field-splitting; the
+  // whole slice is the payload and the format derives from sts[0]. Must
+  // not crash.
+  test('CASE C: multi-char sts -> whole slice payload, no crash, typeChar null', () => {
+    const raw = enc('xy body');
+    const {payload, typeChar} = splitDictEntry('hm', raw);
+    expect(dec(payload)).toBe('xy body');
+    expect(typeChar).toBeNull();
+  });
+
+  test('sts-absent type byte is ASCII (single byte) even before a multibyte body', () => {
+    const raw = new Uint8Array([...enc('m'), ...enc('café 咖啡'), 0x00]);
+    const {payload, typeChar} = splitDictEntry(null, raw);
+    expect(dec(payload)).toBe('café 咖啡');
+    expect(typeChar).toBe('m');
+  });
+});
+
+describe('formatFromTypeChar', () => {
+  test("'h' -> html", () => {
+    expect(formatFromTypeChar('h')).toBe('html');
+  });
+
+  test("'m' -> plain", () => {
+    expect(formatFromTypeChar('m')).toBe('plain');
+  });
+
+  test('null -> plain', () => {
+    expect(formatFromTypeChar(null)).toBe('plain');
+  });
+
+  test('any other char -> plain (never wordnet)', () => {
+    expect(formatFromTypeChar('g')).toBe('plain');
+    expect(formatFromTypeChar('x')).toBe('plain');
+  });
+});

--- a/__tests__/dictEntry.test.ts
+++ b/__tests__/dictEntry.test.ts
@@ -15,11 +15,13 @@ const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
 const dec = (b: Uint8Array): string => new TextDecoder().decode(b);
 
 describe('splitDictEntry', () => {
-  test('sametypesequence PRESENT: whole slice is the payload, no type char', () => {
+  test('sametypesequence PRESENT: whole slice is the payload; typeChar IS sts[0]', () => {
     const raw = enc('a fruit');
     const {payload, typeChar} = splitDictEntry('m', raw);
     expect(dec(payload)).toBe('a fruit');
-    expect(typeChar).toBeNull();
+    // typeChar derives from sts[0] (not null), so the format derivation
+    // call site honours the .ifo-level type even with no sidecar override.
+    expect(typeChar).toBe('m');
   });
 
   test('sametypesequence PRESENT preserves a leading char that is NOT a type prefix', () => {
@@ -73,11 +75,31 @@ describe('splitDictEntry', () => {
   // CASE C: multi-char sts is out of scope for field-splitting; the
   // whole slice is the payload and the format derives from sts[0]. Must
   // not crash.
-  test('CASE C: multi-char sts -> whole slice payload, no crash, typeChar null', () => {
+  test('CASE C: multi-char sts -> whole slice payload, no crash, typeChar = sts[0]', () => {
     const raw = enc('xy body');
-    const {payload, typeChar} = splitDictEntry('hm', raw);
+    const {payload, typeChar} = splitDictEntry('mh', raw);
     expect(dec(payload)).toBe('xy body');
-    expect(typeChar).toBeNull();
+    // Field-splitting is out of scope, but the format still derives from
+    // the FIRST char of the sequence.
+    expect(typeChar).toBe('m');
+    expect(formatFromTypeChar(typeChar)).toBe('plain');
+  });
+
+  // PR #31 regression guard: an .ifo-level sametypesequence must drive
+  // the render format (no per-entry prefix, no sidecar override).
+  test("sts present 'h' -> typeChar 'h' -> format html (v1.3.0 HTML behaviour)", () => {
+    const raw = enc('<b>bold body</b>');
+    const {payload, typeChar} = splitDictEntry('h', raw);
+    expect(dec(payload)).toBe('<b>bold body</b>'); // whole slice, unstripped
+    expect(typeChar).toBe('h');
+    expect(formatFromTypeChar(typeChar)).toBe('html');
+  });
+
+  test("sts present 'm' -> typeChar 'm' -> format plain", () => {
+    const raw = enc('plain body');
+    const {typeChar} = splitDictEntry('m', raw);
+    expect(typeChar).toBe('m');
+    expect(formatFromTypeChar(typeChar)).toBe('plain');
   });
 
   test('sts-absent type byte is ASCII (single byte) even before a multibyte body', () => {

--- a/__tests__/importStardict.test.ts
+++ b/__tests__/importStardict.test.ts
@@ -241,9 +241,20 @@ describe('importStardict — happy path', () => {
     // SIDECAR sets only name + language (no `format`). Forcing 'plain' here
     // would shadow an HTML StarDict's own sametypesequence=h and render its
     // <i>/<ol>/<li> markup as literal text (the fr-en-strdict bug).
-    const h = await makeHarness();
+    // Drive a sts='h' fixture so we assert BOTH that no JS override is
+    // forwarded AND that the derived row format reaches the slug DB as
+    // 'html' (not just that the override is undefined).
+    const h = await makeHarness({
+      nativeRawEntries: {
+        sts: 'h',
+        entries: [{key: 'rich', word: 'rich', raw: new TextEncoder().encode('<i>x</i>')}],
+      },
+    });
     await importStardict(h.ports);
     expect(h.runNativeImport.mock.calls[0][0].format).toBeUndefined();
+    const slug = h.slugFiles.get('my-dict.en.db')!;
+    const rich = await slug.query(SELECT_ENTRY_BY_KEY, ['rich']);
+    expect(rich[0]).toMatchObject({definition: '<i>x</i>', format: 'html'});
   });
 
   it('forwards the optional .syn path to the native import', async () => {
@@ -307,6 +318,40 @@ describe('importStardict — sametypesequence-absent body/format (issue #28)', (
     expect(rich[0]).toMatchObject({definition: '<b>bold</b>', format: 'html'});
     const flat = await slug.query(SELECT_ENTRY_BY_KEY, ['flat']);
     expect(flat[0]).toMatchObject({definition: 'plain text', format: 'plain'});
+  });
+
+  it("sts-PRESENT 'h' with NO sidecar format: rows are format='html' and bodies are the WHOLE slice (PR #31 regression guard)", async () => {
+    // sts is PRESENT -> NO per-entry type prefix and NO terminator; the
+    // body IS the whole slice. With no sidecar override the row format
+    // must STILL derive from sts[0]='h' (the v1.3.0 .ifo-level HTML
+    // behaviour) — regressing this would render <i>/<ol>/<li> as literal
+    // text. This is the device-bug guard the suite was missing.
+    const h = await makeHarness({
+      // SIDECAR (default) omits `format`, so no override reaches native.
+      nativeRawEntries: {
+        sts: 'h',
+        entries: [
+          {key: 'rich', word: 'rich', raw: enc('<b>bold</b>')},
+          {key: 'list', word: 'list', raw: enc('<ol><li>a</li></ol>')},
+        ],
+      },
+    });
+    // No sidecar override is forwarded to native (the .ifo drives format).
+    await importStardict(h.ports);
+    expect(h.runNativeImport.mock.calls[0][0].format).toBeUndefined();
+    const slug = h.slugFiles.get('my-dict.en.db')!;
+    const rich = await slug.query(SELECT_ENTRY_BY_KEY, ['rich']);
+    expect(rich[0]).toEqual({
+      word: 'rich',
+      definition: '<b>bold</b>', // whole slice, NOT stripped
+      format: 'html',
+      phonetic: null,
+    });
+    const list = await slug.query(SELECT_ENTRY_BY_KEY, ['list']);
+    expect(list[0]).toMatchObject({
+      definition: '<ol><li>a</li></ol>',
+      format: 'html',
+    });
   });
 
   it('sidecar format override wins over the per-entry type char', async () => {

--- a/__tests__/importStardict.test.ts
+++ b/__tests__/importStardict.test.ts
@@ -21,6 +21,10 @@ import {
 } from '../src/core/dict/sqlite/schema';
 import type {SqliteDb} from '../src/core/dict/sqlite/db';
 import type {RunNativeImport} from '../src/core/dict/sqlite/nativeImport';
+import {
+  splitDictEntry,
+  formatFromTypeChar,
+} from '../src/core/dict/stardict/dictEntry';
 
 const SIDECAR = JSON.stringify({name: 'My Dict', language: 'en'});
 const DICT_BYTES = 1000;
@@ -46,6 +50,18 @@ type Opts = {
   // The rows the fake native importer "inserts" into the slug DB and
   // the count it reports (default: keyed entries below).
   nativeRows?: Array<{key: string; word: string; definition: string; format: string}>;
+  // Raw StarDict-style entries the fake importer derives rows from by
+  // running the REAL splitDictEntry / formatFromTypeChar helpers — this
+  // encodes the native (Kotlin) semantics in the host fake so the
+  // device-only behaviour is guarded. `sts` is the .ifo
+  // sametypesequence (null = absent); each entry's `raw` is the .dict
+  // slice (type byte + payload + optional NUL when sts absent).
+  // `formatOverride` mirrors the sidecar format passed to native.
+  nativeRawEntries?: {
+    sts: string | null;
+    formatOverride?: string;
+    entries: Array<{key: string; word: string; raw: Uint8Array}>;
+  };
   // Override the count the native side REPORTS (to force a verify
   // mismatch even when rows are inserted) and/or make it throw.
   nativeReports?: number;
@@ -73,16 +89,35 @@ const makeHarness = async (opts: Opts = {}): Promise<Harness> => {
   // The .dict-size port the space guard reads (native stat on-device).
   const statDictSize = jest.fn(async () => opts.dictSize ?? DICT_BYTES);
 
-  const rows = opts.nativeRows ?? DEFAULT_ROWS;
+  const staticRows = opts.nativeRows ?? DEFAULT_ROWS;
 
-  // Fake native import: seed `rows` into a fresh slug DB keyed by the
+  // Fake native import: seed rows into a fresh slug DB keyed by the
   // resolved dbPath's trailing filename, and resolve the reported count.
+  // When `nativeRawEntries` is set, the rows are DERIVED from raw .dict
+  // bytes by running the SAME splitDictEntry / formatFromTypeChar helpers
+  // the device path mirrors — so the fake encodes native semantics
+  // (stripped body + per-entry format) rather than hand-baked rows.
+  const decode = (b: Uint8Array): string => new TextDecoder().decode(b);
   const runNativeImport = jest.fn<ReturnType<RunNativeImport>, Parameters<RunNativeImport>>(
-    async ({dbPath}) => {
+    async ({dbPath, format}) => {
       if (opts.nativeThrows) {
         throw opts.nativeThrows;
       }
       const filename = dbPath.split('/').pop() as string;
+      const rows = opts.nativeRawEntries
+        ? opts.nativeRawEntries.entries.map(e => {
+            const split = splitDictEntry(opts.nativeRawEntries!.sts, e.raw);
+            const rowFormat =
+              (opts.nativeRawEntries!.formatOverride ?? format) ??
+              formatFromTypeChar(split.typeChar);
+            return {
+              key: e.key,
+              word: e.word,
+              definition: decode(split.payload),
+              format: rowFormat,
+            };
+          })
+        : staticRows;
       const db = await createSeededDb(async d => {
         await d.run(CREATE_ENTRIES_TABLE);
         for (const r of rows) {
@@ -218,6 +253,78 @@ describe('importStardict — happy path', () => {
     expect(h.runNativeImport).toHaveBeenCalledWith(
       expect.objectContaining({synPath: 'dict.syn'}),
     );
+  });
+});
+
+describe('importStardict — sametypesequence-absent body/format (issue #28)', () => {
+  // The fake runNativeImport runs the REAL splitDictEntry /
+  // formatFromTypeChar helpers, mirroring the Kotlin importer. These
+  // tests assert the END STATE in the slug DB: definitions are stripped
+  // of the type byte + trailing NUL, and each row's format is derived
+  // per-entry from its type char (unless the sidecar overrides it).
+  const enc = (s: string): Uint8Array => new TextEncoder().encode(s);
+  const rawEntry = (typeChar: string, body: string, withNul: boolean): Uint8Array =>
+    new Uint8Array([
+      ...enc(typeChar),
+      ...enc(body),
+      ...(withNul ? [0x00] : []),
+    ]);
+
+  it('strips the type byte + trailing NUL from each definition (sts absent)', async () => {
+    const h = await makeHarness({
+      nativeRawEntries: {
+        sts: null,
+        entries: [
+          {key: 'apple', word: 'apple', raw: rawEntry('m', 'a fruit', true)},
+          {key: 'banana', word: 'Banana', raw: rawEntry('m', 'a yellow fruit', false)},
+        ],
+      },
+    });
+    const res = await importStardict(h.ports);
+    expect(res.ok).toBe(true);
+    const slug = h.slugFiles.get('my-dict.en.db')!;
+    const apple = await slug.query(SELECT_ENTRY_BY_KEY, ['apple']);
+    expect(apple).toEqual([
+      {word: 'apple', definition: 'a fruit', format: 'plain', phonetic: null},
+    ]);
+    const banana = await slug.query(SELECT_ENTRY_BY_KEY, ['banana']);
+    expect(banana[0]).toMatchObject({definition: 'a yellow fruit'});
+  });
+
+  it("derives format per-entry from the type char ('h' -> html, 'm' -> plain) when the sidecar omits format", async () => {
+    const h = await makeHarness({
+      nativeRawEntries: {
+        sts: null,
+        entries: [
+          {key: 'rich', word: 'rich', raw: rawEntry('h', '<b>bold</b>', true)},
+          {key: 'flat', word: 'flat', raw: rawEntry('m', 'plain text', false)},
+        ],
+      },
+    });
+    await importStardict(h.ports);
+    const slug = h.slugFiles.get('my-dict.en.db')!;
+    const rich = await slug.query(SELECT_ENTRY_BY_KEY, ['rich']);
+    expect(rich[0]).toMatchObject({definition: '<b>bold</b>', format: 'html'});
+    const flat = await slug.query(SELECT_ENTRY_BY_KEY, ['flat']);
+    expect(flat[0]).toMatchObject({definition: 'plain text', format: 'plain'});
+  });
+
+  it('sidecar format override wins over the per-entry type char', async () => {
+    const h = await makeHarness({
+      sidecarText: JSON.stringify({name: 'My Dict', language: 'en', format: 'html'}),
+      nativeRawEntries: {
+        sts: null,
+        formatOverride: 'html',
+        entries: [
+          {key: 'flat', word: 'flat', raw: rawEntry('m', 'plain text', false)},
+        ],
+      },
+    });
+    await importStardict(h.ports);
+    const slug = h.slugFiles.get('my-dict.en.db')!;
+    const flat = await slug.query(SELECT_ENTRY_BY_KEY, ['flat']);
+    // 'm' type would derive 'plain', but the sidecar override forces html.
+    expect(flat[0]).toMatchObject({definition: 'plain text', format: 'html'});
   });
 });
 

--- a/__tests__/stardictDict.test.ts
+++ b/__tests__/stardictDict.test.ts
@@ -57,6 +57,23 @@ describe('stardictDict', () => {
     expect(lookupDict(parsed, '   ')).toBeNull();
   });
 
+  test('sametypesequence-absent dict: type byte + trailing NUL are stripped from the body (issue #28)', async () => {
+    // A StarDict with no sametypesequence stores each entry as
+    // <type-byte><payload>[0x00]. lookupDict must strip the prefix and
+    // the trailing NUL so the user sees the clean definition, not a
+    // leading 'm'/'h' or a trailing control char.
+    const {ifo, idx, dict} = buildSyntheticStarDict(
+      {apple: 'a fruit', banana: 'a yellow fruit'},
+      {omitSametypesequence: true},
+    );
+    const parsed = await buildDict(ifo, idx, dict);
+    expect(parsed.meta.sametypesequence).toBeUndefined();
+    // apple is NOT the last entry -> had a 0x00 terminator that must go.
+    expect(lookupDict(parsed, 'apple')?.definition).toBe('a fruit');
+    // banana is the last entry -> no terminator, only the type byte.
+    expect(lookupDict(parsed, 'banana')?.definition).toBe('a yellow fruit');
+  });
+
   test('decodes UTF-8 multibyte definitions correctly', async () => {
     const {ifo, idx, dict} = buildSyntheticStarDict({
       café: '咖啡 (coffee)',

--- a/__tests__/writeStardict.test.ts
+++ b/__tests__/writeStardict.test.ts
@@ -1,5 +1,8 @@
 import {writeStarDict} from '../src/core/dict/stardict/writeStardict';
 import {buildDict, lookupDict} from '../src/core/dict/stardict/stardictDict';
+import {decodeUtf8} from '../src/sdk/utf8';
+
+const ifoText = (ifo: Uint8Array): string => decodeUtf8(ifo);
 
 describe('writeStarDict', () => {
   test('round-trips through buildDict + lookupDict with no options', async () => {
@@ -26,4 +29,59 @@ describe('writeStarDict', () => {
     expect(parsed.meta.bookname).toBe('Compressed');
     expect(lookupDict(parsed, 'apple')?.definition).toBe('a fruit');
   });
+
+  describe('sametypesequence-absent layout (issue #28)', () => {
+    test('default path stays byte-identical (sametypesequence=m line, raw payloads)', () => {
+      const a = writeStarDict({apple: 'a fruit', banana: 'a yellow fruit'});
+      // .ifo carries the sametypesequence=m line; .dict is the bare
+      // concatenated payloads with no type prefix and no terminators.
+      expect(ifoText(a.ifo)).toContain('sametypesequence=m\n');
+      expect(Array.from(a.dict)).toEqual(
+        Array.from(decodeUtf8Bytes('a fruit' + 'a yellow fruit')),
+      );
+    });
+
+    test('omitSametypesequence drops the .ifo line and prefixes each payload with a type byte', () => {
+      const {ifo, dict} = writeStarDict(
+        {apple: 'a fruit', banana: 'a yellow fruit'},
+        {omitSametypesequence: true},
+      );
+      // No sametypesequence line at all.
+      expect(ifoText(ifo)).not.toContain('sametypesequence');
+      // Layout: 'm' + "a fruit" + 0x00 + 'm' + "a yellow fruit" (no
+      // trailing 0x00 after the LAST entry).
+      const expected = [
+        ...decodeUtf8Bytes('m'),
+        ...decodeUtf8Bytes('a fruit'),
+        0x00,
+        ...decodeUtf8Bytes('m'),
+        ...decodeUtf8Bytes('a yellow fruit'),
+      ];
+      expect(Array.from(dict)).toEqual(expected);
+    });
+
+    test('perEntryType sets the per-word type char (default m); .idx lengths cover prefix + terminator', async () => {
+      const {ifo, idx, dict} = writeStarDict(
+        {alpha: '<b>A</b>', beta: 'plain B'},
+        {omitSametypesequence: true, perEntryType: {alpha: 'h'}},
+      );
+      // alpha (sorts first): 'h' + "<b>A</b>" + 0x00; beta: 'm' + "plain B".
+      const alphaPayload = decodeUtf8Bytes('<b>A</b>');
+      const expected = [
+        ...decodeUtf8Bytes('h'),
+        ...alphaPayload,
+        0x00,
+        ...decodeUtf8Bytes('m'),
+        ...decodeUtf8Bytes('plain B'),
+      ];
+      expect(Array.from(dict)).toEqual(expected);
+      // The .idx record for alpha must span 'h' + payload + the 0x00.
+      const parsed = await buildDict(ifo, idx, dict);
+      const entry = parsed.index.get('alpha')!;
+      expect(entry.length).toBe(1 + alphaPayload.length + 1);
+    });
+  });
 });
+
+const decodeUtf8Bytes = (s: string): Uint8Array =>
+  new TextEncoder().encode(s);

--- a/android/app/src/main/java/com/sndict/imports/StarDictImporter.kt
+++ b/android/app/src/main/java/com/sndict/imports/StarDictImporter.kt
@@ -149,17 +149,20 @@ object StarDictImporter {
 
   private data class SplitEntry(val payload: ByteArray, val typeChar: Char?)
 
-  // sts PRESENT  -> whole slice is the payload, typeChar null.
+  // sts PRESENT  -> whole slice is the payload; typeChar = sts[0] so an
+  //                 .ifo-level sametypesequence=h dict renders HTML even
+  //                 with no per-entry prefix / no sidecar override.
+  //                 multi-char sts (CASE C) still uses sts[0] for format;
+  //                 field-splitting is out of scope.
   // sts ABSENT   -> raw[0] is the ASCII type char; the rest is the body
   //                 minus exactly one trailing 0x00 when present.
   // empty slice  -> {empty, null} (guard before indexing raw[0]).
-  // multi-char sts is out of scope: whole slice payload, typeChar null.
   private fun splitDictEntry(sametypesequence: String?, raw: ByteArray): SplitEntry {
     if (raw.isEmpty()) {
       return SplitEntry(raw, null)
     }
     if (sametypesequence != null && sametypesequence.isNotEmpty()) {
-      return SplitEntry(raw, null)
+      return SplitEntry(raw, sametypesequence.firstOrNull())
     }
     val typeChar = (raw[0].toInt() and 0xff).toChar()
     var end = raw.size

--- a/android/app/src/main/java/com/sndict/imports/StarDictImporter.kt
+++ b/android/app/src/main/java/com/sndict/imports/StarDictImporter.kt
@@ -15,7 +15,10 @@ import java.util.zip.GZIPInputStream
 // SQLite DB, ALL off the Hermes/JS thread. Logic mirrors the TS path
 // EXACTLY so natively-imported dicts are byte-identical to base.db:
 //   - .ifo  -> parseIfo.ts (sametypesequence, idxoffsetbits 32|64)
-//   - .dict -> dictReader (gzip inflate when .dz / 0x1f8b magic)
+//   - .dict -> dictReader (gzip inflate when .dz / 0x1f8b magic);
+//             each entry's slice -> splitDictEntry (strip sts-absent
+//             type byte + trailing NUL) + formatFromTypeChar (mirror
+//             dictEntry.ts) before decode (issue #28)
 //   - .idx  -> parseIdx.ts (word\0 + BE offset(u32|u64) + BE length(u32))
 //   - .syn  -> parseSyn.ts + buildDict merge (.idx first, then .syn,
 //              first-key-wins, normalizeKey-folded, out-of-range skipped)
@@ -49,7 +52,6 @@ object StarDictImporter {
     formatOverride: String?,
   ): Int {
     val ifo = parseIfo(File(ifoPath).readBytes())
-    val format = formatOverride ?: ifo.format
     val builtAt = builtAt(ifo)
 
     // .idx walk holds only words + offsets/lengths (no definitions).
@@ -70,7 +72,8 @@ object StarDictImporter {
         synPath = synPath,
         body = body,
         bodySize = size,
-        format = format,
+        sametypesequence = ifo.sametypesequence,
+        formatOverride = formatOverride,
         builtAt = builtAt,
       )
     } finally {
@@ -117,14 +120,16 @@ object StarDictImporter {
     }
   }
 
-  // Read `length` bytes at `offset` from the mmap'd body -> UTF-8 String.
-  // Bounds-checked (same guard as the prior sliceUtf8).
+  // Read `length` raw bytes at `offset` from the mmap'd body. Bounds-
+  // checked (same guard as before). Returns the RAW slice — the caller
+  // runs splitDictEntry to strip any sts-absent type prefix/NUL BEFORE
+  // decoding to UTF-8 (issue #28; mirrors dictEntry.ts).
   private fun readDef(
     body: MappedByteBuffer,
     bodySize: Long,
     offset: Long,
     length: Int,
-  ): String {
+  ): ByteArray {
     val end = offset + length
     if (offset < 0 || length < 0 || end > bodySize) {
       throw IndexOutOfBoundsException(
@@ -137,13 +142,45 @@ object StarDictImporter {
     val dup = body.duplicate()
     dup.position(offset.toInt())
     dup.get(buf, 0, length)
-    return String(buf, Charsets.UTF_8)
+    return buf
   }
+
+  // --- .dict entry split (mirror dictEntry.ts splitDictEntry EXACTLY) -
+
+  private data class SplitEntry(val payload: ByteArray, val typeChar: Char?)
+
+  // sts PRESENT  -> whole slice is the payload, typeChar null.
+  // sts ABSENT   -> raw[0] is the ASCII type char; the rest is the body
+  //                 minus exactly one trailing 0x00 when present.
+  // empty slice  -> {empty, null} (guard before indexing raw[0]).
+  // multi-char sts is out of scope: whole slice payload, typeChar null.
+  private fun splitDictEntry(sametypesequence: String?, raw: ByteArray): SplitEntry {
+    if (raw.isEmpty()) {
+      return SplitEntry(raw, null)
+    }
+    if (sametypesequence != null && sametypesequence.isNotEmpty()) {
+      return SplitEntry(raw, null)
+    }
+    val typeChar = (raw[0].toInt() and 0xff).toChar()
+    var end = raw.size
+    if (raw[end - 1].toInt() == 0) {
+      end -= 1
+    }
+    return SplitEntry(raw.copyOfRange(1, end), typeChar)
+  }
+
+  // Mirror dictEntry.ts formatFromTypeChar: 'h' -> html, else plain.
+  // NEVER 'wordnet'.
+  private fun formatFromTypeChar(typeChar: Char?): String =
+    if (typeChar == 'h') "html" else "plain"
 
   // --- .ifo (mirror parseIfo.ts) -------------------------------------
 
   private data class IfoMeta(
-    val format: String,
+    // The raw sametypesequence field, or null when absent (mirror
+    // parseIfo.ts IfoMeta.sametypesequence). Drives splitDictEntry +
+    // the per-entry format derivation — NOT a single dict-wide format.
+    val sametypesequence: String?,
     val idxoffsetbits: Int,
     val date: String?,
     val bookname: String?,
@@ -158,9 +195,6 @@ object StarDictImporter {
       val k = line.substring(0, eq).trim()
       if (k.isNotEmpty()) map[k] = line.substring(eq + 1)
     }
-    // sametypesequence -> format (matches formatFromSametypesequence).
-    val sts = map["sametypesequence"]
-    val format = if (sts == "h") "html" else "plain"
     // idxoffsetbits: default 32; only 32|64 allowed (mirror parseIfo).
     val rawBits = map["idxoffsetbits"]
     val bits = when {
@@ -171,7 +205,13 @@ object StarDictImporter {
         "parseIfo: idxoffsetbits must be 32 or 64, got \"$rawBits\"",
       )
     }
-    return IfoMeta(format, bits, map["date"], map["bookname"], map["wordcount"])
+    return IfoMeta(
+      map["sametypesequence"],
+      bits,
+      map["date"],
+      map["bookname"],
+      map["wordcount"],
+    )
   }
 
   // Deterministic built_at (mirror deterministicBuiltAt).
@@ -260,7 +300,12 @@ object StarDictImporter {
     synPath: String?,
     body: MappedByteBuffer,
     bodySize: Long,
-    format: String,
+    // The .ifo sametypesequence (null = absent). Drives splitDictEntry
+    // (strip the per-entry type byte + NUL) and the per-row format
+    // derivation. `formatOverride` (from the validated sidecar) wins
+    // over the derived format when set — precedence: override ?: derived.
+    sametypesequence: String?,
+    formatOverride: String?,
     builtAt: String,
   ): Int {
     // Start clean so reruns are deterministic.
@@ -283,15 +328,21 @@ object StarDictImporter {
           "INSERT INTO entries (key, word, definition, format) VALUES (?, ?, ?, ?)",
         )
         // .idx first (first-key-wins). Only one definition String is
-        // live per iteration (GC-eligible after executeInsert).
+        // live per iteration (GC-eligible after executeInsert). Each
+        // entry's raw .dict slice is split (strip sts-absent type byte +
+        // NUL) BEFORE decode, and its format derived per-entry from the
+        // type char unless the sidecar overrides it (mirror dictEntry.ts).
         for (e in idxEntries) {
           val key = NormalizeKey.fold(e.word)
           if (key.isNotEmpty() && seen.add(key)) {
-            insertRow(stmt, key, e.word, readDef(body, bodySize, e.offset, e.length), format)
+            val split = splitDictEntry(sametypesequence, readDef(body, bodySize, e.offset, e.length))
+            val rowFormat = formatOverride ?: formatFromTypeChar(split.typeChar)
+            insertRow(stmt, key, e.word, String(split.payload, Charsets.UTF_8), rowFormat)
           }
         }
         // .syn aliases -> canonical .idx entry (its headword + def),
-        // mirroring buildDict's merge; out-of-range index skipped.
+        // mirroring buildDict's merge; out-of-range index skipped. The
+        // body + format derive from the TARGET entry's slice.
         if (synPath != null) {
           val synFile = File(synPath)
           if (synFile.exists() && synFile.length() > 0) {
@@ -299,12 +350,17 @@ object StarDictImporter {
               val target = idxEntries.getOrNull(syn.originalWordIndex) ?: continue
               val key = NormalizeKey.fold(syn.word)
               if (key.isNotEmpty() && seen.add(key)) {
+                val split = splitDictEntry(
+                  sametypesequence,
+                  readDef(body, bodySize, target.offset, target.length),
+                )
+                val rowFormat = formatOverride ?: formatFromTypeChar(split.typeChar)
                 insertRow(
                   stmt,
                   key,
                   target.word,
-                  readDef(body, bodySize, target.offset, target.length),
-                  format,
+                  String(split.payload, Charsets.UTF_8),
+                  rowFormat,
                 )
               }
             }

--- a/src/core/dict/sqlite/buildBaseDb.ts
+++ b/src/core/dict/sqlite/buildBaseDb.ts
@@ -9,6 +9,7 @@
 // meta absent, which provisioning reads as "reprovision".
 
 import {buildDict, type ParsedDict} from '../stardict/stardictDict';
+import {splitDictEntry} from '../stardict/dictEntry';
 import {decodeUtf8} from '../../../sdk/utf8';
 import type {DefinitionFormat} from '../../lookup';
 import type {SqliteDb} from './db';
@@ -48,7 +49,11 @@ export const entriesFromParsedDict = (parsed: ParsedDict): BaseDbRow[] => {
   const rows: BaseDbRow[] = [];
   for (const [key, entry] of parsed.index) {
     const slice = parsed.dictReader.slice(entry.offset, entry.length);
-    rows.push({key, word: entry.word, definition: decodeUtf8(slice)});
+    // Same split as lookupDict so the persisted body == the looked-up
+    // body (issue #28). No-op for sts-present dicts like WordNet, so
+    // base.db stays byte-identical.
+    const {payload} = splitDictEntry(parsed.meta.sametypesequence ?? null, slice);
+    rows.push({key, word: entry.word, definition: decodeUtf8(payload)});
   }
   return rows;
 };

--- a/src/core/dict/stardict/dictEntry.ts
+++ b/src/core/dict/stardict/dictEntry.ts
@@ -1,0 +1,64 @@
+// StarDict .dict entry splitter (issue #28). Shared by the host reader
+// (stardictDict.lookupDict) and the host base.db builder
+// (buildBaseDb.entriesFromParsedDict); the Kotlin StarDictImporter
+// mirrors this helper byte-for-byte so device imports stay
+// byte-identical (the device-only-bug guard).
+//
+// StarDict stores an entry's body two ways:
+//   - sametypesequence PRESENT: every entry uses that single type
+//     sequence, so the .dict bytes for an entry ARE the raw payload —
+//     no per-entry type prefix, no terminator. (WordNet/base.db: 'm'.)
+//   - sametypesequence ABSENT: each entry is `<type-char-byte><payload>`
+//     and, when it is NOT the last entry, a single 0x00 terminator.
+//     That leading ASCII type byte and the trailing NUL are METADATA —
+//     leaving them in leaks a stray 'm'/'h' char and a control byte into
+//     every definition (the issue-#28 bug).
+//
+// We strip on the raw BYTES, before UTF-8 decode, so a multibyte body
+// is never mis-sliced. The type char is a single ASCII byte by spec.
+
+import type {DefinitionFormat} from '../../lookup';
+
+export type SplitDictEntry = {
+  // The body bytes, with any sts-absent type prefix and one trailing
+  // 0x00 removed. Decode this (UTF-8) to get the definition string.
+  payload: Uint8Array;
+  // The single ASCII type char read from an sts-ABSENT entry (e.g. 'm',
+  // 'h'), or null when sts is present, the slice is empty, or sts is
+  // multi-char (field-splitting is out of scope — see CASE C).
+  typeChar: string | null;
+};
+
+export const splitDictEntry = (
+  sametypesequence: string | null,
+  raw: Uint8Array,
+): SplitDictEntry => {
+  // Empty slice: nothing to strip or read. Guard before any indexing so
+  // a zero-length .dict record can't crash on raw[0].
+  if (raw.length === 0) {
+    return {payload: raw, typeChar: null};
+  }
+  // sts PRESENT: the whole slice is the payload regardless of how many
+  // type chars the field declares. Multi-char field-splitting is out of
+  // scope (CASE C) — we still return the whole slice and never derive a
+  // typeChar from it (format comes from sts[0] at the call site).
+  if (sametypesequence !== null && sametypesequence.length > 0) {
+    return {payload: raw, typeChar: null};
+  }
+  // sts ABSENT: first byte is the ASCII type char; the rest is the body,
+  // minus exactly one trailing 0x00 when present (the inter-entry
+  // terminator — the last entry has none).
+  const typeChar = String.fromCharCode(raw[0]);
+  let end = raw.length;
+  if (raw[end - 1] === 0x00) {
+    end -= 1;
+  }
+  return {payload: raw.subarray(1, end), typeChar};
+};
+
+// Map a StarDict type char to the popup's render format. 'h' is HTML;
+// everything else (incl. 'm' and null) is plain. NEVER 'wordnet' — that
+// is reserved for the bundled base build, which sets it explicitly.
+export const formatFromTypeChar = (
+  typeChar: string | null,
+): DefinitionFormat => (typeChar === 'h' ? 'html' : 'plain');

--- a/src/core/dict/stardict/dictEntry.ts
+++ b/src/core/dict/stardict/dictEntry.ts
@@ -23,9 +23,12 @@ export type SplitDictEntry = {
   // The body bytes, with any sts-absent type prefix and one trailing
   // 0x00 removed. Decode this (UTF-8) to get the definition string.
   payload: Uint8Array;
-  // The single ASCII type char read from an sts-ABSENT entry (e.g. 'm',
-  // 'h'), or null when sts is present, the slice is empty, or sts is
-  // multi-char (field-splitting is out of scope — see CASE C).
+  // The single ASCII type char that drives the render format: the
+  // per-entry prefix byte for an sts-ABSENT entry, or sts[0] when
+  // sametypesequence is present (incl. multi-char sts — CASE C — where
+  // field-splitting is out of scope but the format still derives from
+  // the first char). null only for an empty slice. formatFromTypeChar
+  // is the single derivation point.
   typeChar: string | null;
 };
 
@@ -39,11 +42,13 @@ export const splitDictEntry = (
     return {payload: raw, typeChar: null};
   }
   // sts PRESENT: the whole slice is the payload regardless of how many
-  // type chars the field declares. Multi-char field-splitting is out of
-  // scope (CASE C) — we still return the whole slice and never derive a
-  // typeChar from it (format comes from sts[0] at the call site).
+  // type chars the field declares, and the type char IS sts[0] — so an
+  // .ifo-level sametypesequence=h dict renders as HTML even with no
+  // per-entry prefix and no sidecar override. Multi-char field-splitting
+  // (CASE C) is still out of scope: the payload stays the whole slice,
+  // but the format derives from sts[0].
   if (sametypesequence !== null && sametypesequence.length > 0) {
-    return {payload: raw, typeChar: null};
+    return {payload: raw, typeChar: sametypesequence[0]};
   }
   // sts ABSENT: first byte is the ASCII type char; the rest is the body,
   // minus exactly one trailing 0x00 when present (the inter-entry

--- a/src/core/dict/stardict/parseIfo.ts
+++ b/src/core/dict/stardict/parseIfo.ts
@@ -14,9 +14,11 @@ export type IfoMeta = {
   // 32 = 4-byte offsets in .idx (default); 64 = 8-byte for very large
   // dictionaries. Anything else is rejected as malformed.
   idxoffsetbits: 32 | 64;
-  // If present, all entries in .dict use this single type sequence and
-  // the .dict bytes for an entry are exactly its raw payload (no
-  // type prefix). The most common value is 'm' (pure UTF-8 text).
+  // If present, all entries share this single type sequence and the
+  // .dict bytes for an entry are exactly its raw payload. If ABSENT,
+  // each entry is `<type-char-byte><payload>` plus a 0x00 terminator
+  // except the last; splitDictEntry strips that metadata. Most common
+  // value is 'm' (pure UTF-8 text); 'h' is HTML.
   sametypesequence?: string;
   rawFields: Record<string, string>;
 };

--- a/src/core/dict/stardict/stardictDict.ts
+++ b/src/core/dict/stardict/stardictDict.ts
@@ -21,6 +21,7 @@ import {parseSyn} from './parseSyn';
 import type {DictReader} from './dictReader';
 import {createDictReader} from './dictReader';
 import {decodeUtf8} from '../../../sdk/utf8';
+import {splitDictEntry} from './dictEntry';
 import {normalizeKey} from '../normalizeKey';
 import {shouldYield, yieldToEventLoop} from '../yieldOften';
 
@@ -104,6 +105,9 @@ export const lookupDict = (
     return null;
   }
   const slice = dict.dictReader.slice(entry.offset, entry.length);
-  const definition = decodeUtf8(slice);
+  // Strip the sts-absent per-entry type byte + trailing NUL before
+  // decode (issue #28); a no-op when sametypesequence is present.
+  const {payload} = splitDictEntry(dict.meta.sametypesequence ?? null, slice);
+  const definition = decodeUtf8(payload);
   return {canonicalWord: entry.word, definition};
 };

--- a/src/core/dict/stardict/writeStardict.ts
+++ b/src/core/dict/stardict/writeStardict.ts
@@ -37,6 +37,17 @@ export type WriteOptions = {
   // UTF-8 text (default), 'h' = HTML, others are dict-specific.
   // The reader picks rendering based on this field.
   sametypesequence?: string;
+  // Emit the "sametypesequence-absent" .dict layout that StarDicts in
+  // the wild use when entries can carry mixed types: NO sametypesequence
+  // line in the .ifo, each entry's payload prefixed with a single ASCII
+  // type char byte (default 'm'), and a 0x00 terminator after every
+  // entry EXCEPT the last. Lets tests reproduce the issue-#28 layout the
+  // splitDictEntry helper must handle. The default (sts-present) path is
+  // unaffected and stays byte-identical.
+  omitSametypesequence?: boolean;
+  // Per-word type char used in the omit-sametypesequence layout. Words
+  // not listed default to 'm'. Ignored when omitSametypesequence is off.
+  perEntryType?: Record<string, string>;
 };
 
 export const writeStarDict = (
@@ -45,10 +56,12 @@ export const writeStarDict = (
 ): StarDictBytes => {
   // .idx is sorted by case-sensitive byte order in the StarDict spec.
   const sortedWords = Object.keys(entries).sort();
+  const omitSts = options.omitSametypesequence === true;
   const dictParts: Uint8Array[] = [];
   const idxBuilder: number[] = [];
   let offset = 0;
-  for (const word of sortedWords) {
+  for (let w = 0; w < sortedWords.length; w++) {
+    const word = sortedWords[w];
     const def = entries[word];
     const defBytes = encodeUtf8(def);
     const wordBytes = encodeUtf8(word);
@@ -56,10 +69,26 @@ export const writeStarDict = (
       idxBuilder.push(b);
     }
     idxBuilder.push(0);
+    // sts-absent layout: prefix a single type-char byte, then append a
+    // 0x00 terminator after every entry EXCEPT the last (mirrors the
+    // real-world StarDicts splitDictEntry must parse). The .idx length
+    // covers the prefix + payload + terminator so a reader slices the
+    // whole record. sts-present layout is byte-identical to before.
+    let entryBytes = defBytes;
+    if (omitSts) {
+      const typeChar = options.perEntryType?.[word] ?? 'm';
+      const prefix = encodeUtf8(typeChar);
+      const isLast = w === sortedWords.length - 1;
+      const trailer = isLast ? 0 : 1;
+      entryBytes = new Uint8Array(prefix.length + defBytes.length + trailer);
+      entryBytes.set(prefix, 0);
+      entryBytes.set(defBytes, prefix.length);
+      // Trailing byte is left as the zero-initialized 0x00 when present.
+    }
     writeU32BE(idxBuilder, offset);
-    writeU32BE(idxBuilder, defBytes.length);
-    dictParts.push(defBytes);
-    offset += defBytes.length;
+    writeU32BE(idxBuilder, entryBytes.length);
+    dictParts.push(entryBytes);
+    offset += entryBytes.length;
   }
   const totalDict = dictParts.reduce((s, p) => s + p.length, 0);
   const rawDict = new Uint8Array(totalDict);
@@ -77,7 +106,9 @@ export const writeStarDict = (
     `wordcount=${sortedWords.length}\n` +
     `idxfilesize=${idx.length}\n` +
     'idxoffsetbits=32\n' +
-    `sametypesequence=${options.sametypesequence ?? 'm'}\n`;
+    // sts-absent layout omits the sametypesequence line entirely (the
+    // type char lives per-entry in the .dict). Default keeps the line.
+    (omitSts ? '' : `sametypesequence=${options.sametypesequence ?? 'm'}\n`);
   const ifo = encodeUtf8(ifoText);
   return {ifo, idx, dict};
 };


### PR DESCRIPTION
## Problem (issue #28)

StarDict dictionaries whose `.ifo` omits `sametypesequence` store each `.dict` entry as `<type-char-byte><payload>` plus a trailing `0x00` (on every entry but the last). Neither the device importer (`StarDictImporter.kt`) nor the host reader (`stardictDict.ts`) stripped that byte, so:

- the type char (`h`/`m`/…) was **fused to the front of every definition** ("prefix on every line"), and
- HTML-bodied per-entry dicts were misclassified `plain` and rendered as **flat text with raw tags**.

The v1.3.0 fix (`ab62eaf`) only handled `.ifo`-level `sametypesequence=h`, so the far more common per-entry-typed layout — which is what `@ducduaday` has — stayed broken. (Root-cause: the test writer always emitted a `sametypesequence` line, so no test could reproduce the buggy layout.)

## Fix

- **`src/core/dict/stardict/dictEntry.ts`** (new) — shared `splitDictEntry(sametypesequence, raw) → {payload, typeChar}` and `formatFromTypeChar` (`h→html`, else `plain`, never `wordnet`). Strips on raw bytes **before** UTF-8 decode; removes exactly one trailing `0x00`; crash-safe on empty and multi-char `sametypesequence` slices.
- **`stardictDict.ts` / `buildBaseDb.ts`** — split before decode (read/persist body parity preserved).
- **`StarDictImporter.kt`** — mirrors the TS helper **byte-for-byte**; derives format **per row** so per-entry HTML stores `format='html'`; sidecar `formatOverride` still wins whole-dict.
- **`writeStardict.ts`** — `omitSametypesequence`/`perEntryType` options so the suite can finally produce the no-`sametypesequence` layout (closes the original test blind spot).
- `importStardict.ts` / `SourceSection.tsx` unchanged.

## Scope / safety

- **base.db is byte-identical** — the WordNet source declares `sametypesequence`, so `splitDictEntry` is a no-op there (byte-equality asserted in tests).
- Multi-char `sametypesequence` field-splitting is intentionally **out of scope** but crash-safe.

## Tests & gates

- New `dictEntry` unit table (CASE A/B, empty slice, multi-char no-crash, multibyte body), `lookupDict` strip, per-entry format derivation via the import fake, and a base.db byte-equality regression guard.
- `npm run lint` 0 errors · `npm test` **1142 passed / 3 skipped** · coverage **99.46% stmt / 97.17% branch** (≥97% gate) · no new `tsc` errors.
- Independently reviewed (Kotlin↔TS mirror confirmed clause-by-clause incl. signed-byte and empty-slice traps): **SHIP**.

## ⚠️ Required before merge/release

`StarDictImporter.kt` changed, so this needs **`./buildPlugin.sh` + on-device verification** with a real no-`sametypesequence` HTML StarDict. The host suite cannot prove the native path (the import fake re-uses the TS helper).

Closes #28