### PR TITLE
fix(release): let the Release workflow own version bumps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,9 +132,14 @@ jobs:
           echo "prev_tag=$PREV_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Bump package.json (runner only)
+        # The release workflow OWNS the version bump — package.json must
+        # not be hand-edited in feature PRs. --allow-same-version keeps
+        # the release idempotent so a stray manual bump (or a re-run)
+        # can't wedge it with "Version not changed". The "tag already
+        # exists" guard above is what actually prevents double-releasing.
         env:
           VERSION: ${{ steps.ver.outputs.version }}
-        run: npm version "$VERSION" --no-git-tag-version
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Build plugin
         # buildPlugin.sh runs `npm run prepare:dict` internally which
@@ -159,8 +164,16 @@ jobs:
           # it too so the repo's PluginConfig.json doesn't drift out of
           # sync with the git tag.
           if [ -f PluginConfig.json ]; then git add PluginConfig.json; fi
-          git commit -m "chore(release): $TAG"
-          git push origin HEAD:master
+          # If package.json was already at the target version (idempotent
+          # re-run), there may be nothing staged. Skip the commit rather
+          # than fail with "nothing to commit"; the tag below is what the
+          # release actually needs.
+          if git diff --cached --quiet; then
+            echo "No version-file changes to commit; proceeding to tag."
+          else
+            git commit -m "chore(release): $TAG"
+            git push origin HEAD:master
+          fi
           git tag -a "$TAG" -m "$TAG"
           git push origin "$TAG"
 

--- a/PluginConfig.json
+++ b/PluginConfig.json
@@ -2,8 +2,8 @@
   "name": "{\"en\":\"Dictionary\",\"zh_CN\":\"词典\",\"zh_TW\":\"詞典\",\"ja\":\"辞書\",\"th\":\"พจนานุกรม\",\"nl\":\"Woordenboek\",\"de\":\"Wörterbuch\"}",
   "desc": "Tap or lasso a word on your Supernote and see its definition. Offline-first dictionary plugin with optional user-supplied dictionaries.",
   "iconPath": "assets/icon.png",
-  "versionName": "1.3.2",
-  "versionCode": "10302",
+  "versionName": "1.3.1",
+  "versionCode": "10301",
   "pluginID": "sndictdfltbasev1",
   "pluginKey": "SnDict",
   "jsMainPath": "index"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "SnDict",
-  "version": "1.3.2",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "SnDict",
-      "version": "1.3.2",
+      "version": "1.3.1",
       "dependencies": {
         "pako": "^2.1.0",
         "react": "19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "SnDict",
-  "version": "1.3.2",
+  "version": "1.3.1",
   "description": "Tap or lasso a word on your Supernote and see its definition. Offline-first dictionary plugin with optional user-supplied dictionaries.",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Problem
The **Release** workflow failed at the *Bump package.json* step with `npm error Version not changed` (run [28749651568](https://github.com/j-raghavan/sn-dictionary/actions/runs/28749651568)). CI itself is green.

**Root cause:** feature commit `0bf924e` hand-edited the version in `package.json`, `package-lock.json`, and `PluginConfig.json` from `1.3.1` → `1.3.2`. But the Release workflow is designed to *own* the bump (`npm version` → commit). Since package.json was already `1.3.2`, `npm version 1.3.2` was a no-op and exited non-zero, wedging every release attempt. No `v1.3.2` tag/Release was created.

## Fix
Version bumps belong to the Release workflow, not feature PRs:

1. **Revert the manual bump** back to the last released version `1.3.1` (`package.json`, the two self-version fields in `package-lock.json`, and `PluginConfig.json` → `versionName 1.3.1` / `versionCode 10301`). Dependency versions in the lock file are untouched. The workflow now performs the `1.3.2` bump itself.
2. **Harden `release.yml`** so a stray manual edit or a re-run can't wedge a release again:
   - `npm version … --allow-same-version` → no-op instead of error when already at target.
   - Skip the bump-commit when nothing is staged → an idempotent re-run reaches the tag step instead of dying on "nothing to commit". The existing *tag already exists* guard remains the real double-release safeguard.

## Verification
- `npx eslint`: 0 errors (1 pre-existing warning in `index.js`, untouched)
- `npx jest`: 1219 passed, 3 skipped
- Version fields consistent at `1.3.1`; dependency `@hapi/bourne@1.3.2` left alone

## After merge
Re-dispatch the Release workflow (blank version → auto-bumps `v1.3.1` → `1.3.2`). It will bump, build, commit, and tag `v1.3.2` cleanly.